### PR TITLE
change 'CaQtDM_Lib::Python_Error' local variable 'errorStr' to 'const'

### DIFF
--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -3807,7 +3807,7 @@ bool CaQtDM_Lib::Python_Error(QWidget *w, QString message)
 
     PyObject *errObj = NULL, *errData = NULL, *errTraceback = NULL, *pystring = NULL;
     char errorType[1024], errorInfo[1024], asc[MAX_STRING_LENGTH];
-    char *errorStr = 0;
+    const char *errorStr = 0;
 
     // get latest python exception info
     PyErr_Fetch(&errObj, &errData, &errTraceback);


### PR DESCRIPTION
Seems that Python 3.7 changed the 'PyUnicode_AsUTF8' API (see https://bugs.python.org/issue28769): fix is to set local variable 'errorStr' of 'CaQtDM_Lib::Python_Error' to 'const'; should not cause any problems with pre-3.7 Python versions.
