### PR TITLE
Fixed pv name not being copied to clipboard

### DIFF
--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -94,7 +94,7 @@ public:
     void getWidgetInfo(QString* pv, int& nbPV, int& limitsDefault, int& precMode, int& limitsMode,
                                     int& Precision, char* colMode, double& limitsMax, double& limitsMin);
     void createContextMenu(QMenu& menu);
-    QString getDragText(){ return "hello"; }
+    QString getDragText() { return getPV();}
     // caWidgetInterface implementation finish
 
     // other stuff


### PR DESCRIPTION
Fixed pv name not being copied to clipboard when clicked on with middle mouse button in calinedraw