### PR TITLE
Restyled caTable and caWaveTable

### DIFF
--- a/caQtDM_QtControls/src/catable.cpp
+++ b/caQtDM_QtControls/src/catable.cpp
@@ -63,6 +63,37 @@ caTable::caTable(QWidget *parent) : QTableWidget(parent)
     horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
     defaultForeColor = palette().windowText().color();
 
+    //Iterate over every parent QWidget and check if any styles have been applied to it in designer --> If at any point any styles have been applied, do not overwrite them, else set the style so it looks like before the update.
+    bool canSetStyle = true;
+    for(QWidget *checkWidget = this;checkWidget->parentWidget();checkWidget = checkWidget->parentWidget()){
+        if (!(checkWidget->styleSheet().isEmpty())){
+            //qDebug().noquote()<<QString("Style for a child widget of %1 is NOT set by object, preferring Style from designer").arg(this->parentWidget()->objectName());
+            canSetStyle = false;
+            break;
+        }
+    }
+    if (canSetStyle){
+        //qDebug().noquote()<<QString("Style for a child widget of %1 is set by object").arg(this->parentWidget()->objectName());
+        QPalette p = QPalette();
+        p.setColor(QPalette::AlternateBase, QColor(233, 231, 227));
+        setPalette(p);
+        setStyleSheet(
+            "QHeaderView::section{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom: 1px solid #D8D8D8;"
+            "background-color:#f0f0f0;"
+            "}"
+            "QTableCornerButton::section{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom: 1px solid #D8D8D8;"
+            "background-color:#f0f0f0;"
+            "}"
+            "QScrollBar{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom:1px solid #D8D8D8"
+            "}");
+        //}
+    }
 #endif
     createActions();
     addAction(copyAct);

--- a/caQtDM_QtControls/src/catable.cpp
+++ b/caQtDM_QtControls/src/catable.cpp
@@ -92,7 +92,6 @@ caTable::caTable(QWidget *parent) : QTableWidget(parent)
             "border-right:1px solid #D8D8D8;"
             "border-bottom:1px solid #D8D8D8"
             "}");
-        //}
     }
 #endif
     createActions();

--- a/caQtDM_QtControls/src/cawavetable.cpp
+++ b/caQtDM_QtControls/src/cawavetable.cpp
@@ -67,9 +67,41 @@ caWaveTable::caWaveTable(QWidget *parent) : QTableWidget(parent)
     verticalHeader()->setSortIndicatorShown(false);
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-           horizontalHeader()->setResizeMode(QHeaderView::Stretch);
+    horizontalHeader()->setResizeMode(QHeaderView::Stretch);
 #else
-           horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+
+    //Iterate over every parent QWidget and check if any styles have been applied to it in designer --> If at any point any styles have been applied, do not overwrite them, else set the style so it looks like before the update.
+    bool canSetStyle = true;
+    for(QWidget *checkWidget = this;checkWidget->parentWidget();checkWidget = checkWidget->parentWidget()){
+        if (!(checkWidget->styleSheet().isEmpty())){
+            //qDebug().noquote()<<QString("Style for a child widget of %1 is NOT set by object, preferring Style from designer").arg(this->parentWidget()->objectName());
+            canSetStyle = false;
+            break;
+        }
+    }
+    if (canSetStyle){
+        //qDebug().noquote()<<QString("Style for a child widget of %1 is set by object").arg(this->parentWidget()->objectName());
+        QPalette p = QPalette();
+        p.setColor(QPalette::AlternateBase, QColor(233, 231, 227));
+        setPalette(p);
+        setStyleSheet(
+            "QHeaderView::section{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom: 1px solid #D8D8D8;"
+            "background-color:#f0f0f0;"
+            "}"
+            "QTableCornerButton::section{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom: 1px solid #D8D8D8;"
+            "background-color:#f0f0f0;"
+            "}"
+            "QScrollBar{"
+            "border-right:1px solid #D8D8D8;"
+            "border-bottom:1px solid #D8D8D8"
+            "}");
+        //}
+    }
 #endif
     setColumnSize(80);
     setAttribute(Qt::WA_Hover);

--- a/caQtDM_QtControls/src/cawavetable.cpp
+++ b/caQtDM_QtControls/src/cawavetable.cpp
@@ -100,7 +100,6 @@ caWaveTable::caWaveTable(QWidget *parent) : QTableWidget(parent)
             "border-right:1px solid #D8D8D8;"
             "border-bottom:1px solid #D8D8D8"
             "}");
-        //}
     }
 #endif
     setColumnSize(80);


### PR DESCRIPTION
Restyled caTable and caWaveTable on QT 6 so they look like they did on previous versions. They are not restyled, if a stylesheet is already present in the UI file. This is checked by recursively going through all parent widgets of the catable/cawavetable, but only looking at QFrames, so QTabFrames or other frames that are used to style bigger areas can still contain stylesheets.