### PR TITLE
expanded special character support in units

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,4 +92,8 @@ Following environment variables can be used to configure caqtdm:
 - __CAQTDM_FINDRECORD_LIMIT__ - search limit max number of entries
 
 - __CAQTDM_FINDRECORD_DIRECT__ - override all other find record settings (direct json http download)
-|
+
+- __CAQTDM_DEFAULT_UNIT_REPLACEMENTS__ - if set to "false", default unit replacements (°/µ) are disabled.
+
+- __CAQTDM_CUSTOM_UNIT_REPLACEMENTS__ - define custom unit replacements. They are replaced after default replacements took place, if enabled. You can use unicode characters or hexadecimal / decimal utf-8 character codes, seperated by (,) , (=) and (;).
+Examples: "0xba,C=55,abc,0xb0;cd=23;0x43=0x44" , "°=0xba"

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -7429,6 +7429,7 @@ void CaQtDM_Lib::DisplayContextMenu(QWidget* w)
                         info.append(asc);
 
                         info.append("<br>Value: ");
+                        const std::string edataUnits = QString::fromLatin1((const char*)&kPtr->edata.units,strlen(kPtr->edata.units)).toStdString();
                         switch (kPtr->edata.fieldtype) {
                         case caCHAR:
                             snprintf(asc, MAX_STRING_LENGTH, "%ld (0x%x)", kPtr->edata.ivalue, kPtr->edata.ivalue);
@@ -7448,7 +7449,7 @@ void CaQtDM_Lib::DisplayContextMenu(QWidget* w)
                             break;
 
                         case caENUM:{
-                            snprintf(asc, MAX_STRING_LENGTH, "%ld %s", kPtr->edata.ivalue, kPtr->edata.units);
+                            snprintf(asc, MAX_STRING_LENGTH, "%ld %s", kPtr->edata.ivalue, edataUnits.c_str());
                             info.append(asc);
                             snprintf(asc, MAX_STRING_LENGTH, "<br>nbStates: %d", kPtr->edata.enumCount);
                             info.append(asc);
@@ -7466,12 +7467,12 @@ void CaQtDM_Lib::DisplayContextMenu(QWidget* w)
                         }
                         case caINT:
                         case caLONG:
-                            snprintf(asc, MAX_STRING_LENGTH, "%ld (0x%x) %s", kPtr->edata.ivalue, kPtr->edata.ivalue, kPtr->edata.units);
+                            snprintf(asc, MAX_STRING_LENGTH, "%ld (0x%x) %s", kPtr->edata.ivalue, kPtr->edata.ivalue, edataUnits.c_str());
                             info.append(asc);
                             break;
                         case caFLOAT:
                         case caDOUBLE:
-                            snprintf(asc, MAX_STRING_LENGTH, "%lf %s", kPtr->edata.rvalue, kPtr->edata.units);
+                            snprintf(asc, MAX_STRING_LENGTH, "%lf %s", kPtr->edata.rvalue, edataUnits.c_str());
                             info.append(asc);
                             break;
 

--- a/caQtDM_Lib/src/mutexKnobData.cpp
+++ b/caQtDM_Lib/src/mutexKnobData.cpp
@@ -87,9 +87,9 @@ MutexKnobData::MutexKnobData()
                                                "?J=0x00b5,0x004A;"
                                                "uJ=0x00b5,0x004A");
 #else
-    // Degree char coming from epics (0x00b0)    |||||    is replaced with two characters, one being an alternative degree charachter (0x00ba), the other being an Â (0x00c2).
-    // Without this Â char the degree character  ⌄⌄⌄⌄⌄  cannot be displayed correctly, the Â itself is not displayed.
-    QString defaultReplaceUnitString = QString( "0x00b0=0x00c2,0x00ba;"
+    // Degree char coming from epics (0x00b0)    |||||    is replaced with two characters, one being the degree charachter itself (0x00b0), the other being an Â (0x00c2).
+    // Without this Â char the degree character  ⌄⌄⌄⌄⌄  cannot be displayed correctly, the Â itself is not displayed. We don't know why though.
+    QString defaultReplaceUnitString = QString( "0x00b0=0x00c2,0x00b0;"
                                                 "0x00b5=0x00ce,0x00bc;"
                                                 "muA=0x00ce,0x00bc,0x0041;"
                                                 "uA=0x00ce,0x00bc,0x0041;"

--- a/caQtDM_Lib/src/mutexKnobData.cpp
+++ b/caQtDM_Lib/src/mutexKnobData.cpp
@@ -98,7 +98,7 @@ MutexKnobData::MutexKnobData()
                                                 "?J=0x00ce,0x00bc,0x004A;"
                                                 "uJ=0x00ce,0x00bc,0x004A");
 #endif
-    // Convert the values from CAQTDM_REPLACE_UNITS (from QString replaceUnits) in QStrings that can be inserted into a map to then easily replace all the strings.
+    // Convert the values from CAQTDM_CUSTOM_UNIT_REPLACEMENTS (from QString replaceUnits) in QStrings that can be inserted into a map to then easily replace all the strings.
     QStringList replaceUnitsList = createUnitReplacementList();
 
     // Initialize QMaps for default unit replacement and user defined unit replacement.
@@ -124,23 +124,22 @@ QList<QPair<QString, QString> > MutexKnobData::createUnitReplacementPairList(QSt
     QList<QPair<QString, QString> > replaceUnitsPairList;
     if (replaceUnitsList.length() > 0) 
     {   
-	QStringList::iterator replaceUnitsListIterator;
-        for (replaceUnitsListIterator = replaceUnitsList.begin();replaceUnitsListIterator < replaceUnitsList.end(); replaceUnitsListIterator++){
+        QStringList::iterator replaceUnitsListIterator;
+        for (replaceUnitsListIterator = replaceUnitsList.begin(); replaceUnitsListIterator < replaceUnitsList.end(); ++replaceUnitsListIterator){
             QStringList unitHalfs = replaceUnitsListIterator->split("=");
-            if (unitHalfs.length()%2!=0){
-                continue;
-            }
+            if (unitHalfs.length()%2!=0) continue;
+
             QStringList unitKeyParts = unitHalfs[0].split(",");
             QStringList unitValueParts = unitHalfs[1].split(",");
             QString unitKey = "";
             QString unitValue = "";
-	    QStringList::iterator unitPartsIterator;
-	    for (unitPartsIterator = unitKeyParts.begin();unitPartsIterator < unitKeyParts.end();unitPartsIterator++) {
+            QStringList::iterator unitPartsIterator;
+            for (unitPartsIterator = unitKeyParts.begin(); unitPartsIterator < unitKeyParts.end(); ++unitPartsIterator) {
                 bool hexOk = true;
                 bool decOk = true;
                 quint16 parsedValueHex = unitPartsIterator->toInt(&hexOk, 16);
                 quint16 parsedValueDez = unitPartsIterator->toInt(&decOk, 10);
-                if (hexOk && unitPartsIterator->startsWith("0x")){
+                if (hexOk && unitPartsIterator->toLower().startsWith("0x")){
                     unitKey += QString(parsedValueHex);
                 } else if (decOk) {
                     unitKey += QString(parsedValueDez);
@@ -149,12 +148,12 @@ QList<QPair<QString, QString> > MutexKnobData::createUnitReplacementPairList(QSt
                     unitKey += QString(*unitPartsIterator);
                 }
             }
-            for (unitPartsIterator = unitValueParts.begin();unitPartsIterator < unitValueParts.end();unitPartsIterator++) {
+            for (unitPartsIterator = unitValueParts.begin(); unitPartsIterator < unitValueParts.end(); ++unitPartsIterator) {
                 bool hexOk = true;
                 bool decOk = true;
                 quint16 parsedValueHex = unitPartsIterator->toInt(&hexOk, 16);
                 quint16 parsedValueDez = unitPartsIterator->toInt(&decOk, 10);
-                if (hexOk && unitPartsIterator->startsWith("0x")){
+                if (hexOk && unitPartsIterator->toLower().startsWith("0x")){
                     unitValue += QString(parsedValueHex);
                 } else if (decOk) {
                     unitValue += QString(parsedValueDez);
@@ -872,13 +871,13 @@ void MutexKnobData::UpdateWidget(int index, QWidget* w, char *units, char *fec, 
 
         if (doDefaultUnitReplacements){
             // replace default QStrings
-            for (i = defaultReplaceUnitsPairList.begin(); i != defaultReplaceUnitsPairList.end(); ++i){
+            for (i = defaultReplaceUnitsPairList.begin(); i < defaultReplaceUnitsPairList.end(); ++i){
                 StringUnits.replace(i->first, i->second);
             }
         }
 
         // replace QStrings defined in CAQTDM_REPLACE_UNITS
-        for (i = replaceUnitsPairList.begin(); i != replaceUnitsPairList.end(); ++i){
+        for (i = replaceUnitsPairList.begin(); i < replaceUnitsPairList.end(); ++i){
             StringUnits.replace(i->first, i->second);
         }
 
@@ -887,7 +886,6 @@ void MutexKnobData::UpdateWidget(int index, QWidget* w, char *units, char *fec, 
     // send data to main thread
     emit Signal_UpdateWidget(index, w, StringUnits, fec, dataString, knb);
 }
-//*********************************************************************************************************************
 void MutexKnobData::UpdateTextLine(char *message, char *name)
 {
     QString String = QString::fromLatin1(message);

--- a/caQtDM_Lib/src/mutexKnobData.cpp
+++ b/caQtDM_Lib/src/mutexKnobData.cpp
@@ -78,7 +78,7 @@ MutexKnobData::MutexKnobData()
     doDefaultUnitReplacements = true;
     if (qgetenv("CAQTDM_DEFAULT_UNIT_REPLACEMENTS").toLower().replace("\"","") == "false") doDefaultUnitReplacements = false;
 
-// Create unit replacement strings
+    // Create unit replacement strings
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     QString defaultReplaceUnitString = QString( "muA=0x00b5,0x0041;"
                                                "uA=0x00b5,0x0041;"

--- a/caQtDM_Lib/src/mutexKnobData.cpp
+++ b/caQtDM_Lib/src/mutexKnobData.cpp
@@ -125,7 +125,7 @@ QList<QPair<QString, QString> > MutexKnobData::createUnitReplacementPairList(QSt
     if (replaceUnitsList.length() > 0) 
     {   
         QStringList::iterator replaceUnitsListIterator;
-        for (replaceUnitsListIterator = replaceUnitsList.begin(); replaceUnitsListIterator < replaceUnitsList.end(); ++replaceUnitsListIterator){
+        for (replaceUnitsListIterator = replaceUnitsList.begin(); replaceUnitsListIterator != replaceUnitsList.end(); ++replaceUnitsListIterator){
             QStringList unitHalfs = replaceUnitsListIterator->split("=");
             if (unitHalfs.length()%2!=0) continue;
 
@@ -134,7 +134,7 @@ QList<QPair<QString, QString> > MutexKnobData::createUnitReplacementPairList(QSt
             QString unitKey = "";
             QString unitValue = "";
             QStringList::iterator unitPartsIterator;
-            for (unitPartsIterator = unitKeyParts.begin(); unitPartsIterator < unitKeyParts.end(); ++unitPartsIterator) {
+            for (unitPartsIterator = unitKeyParts.begin(); unitPartsIterator != unitKeyParts.end(); ++unitPartsIterator) {
                 bool hexOk = true;
                 bool decOk = true;
                 quint16 parsedValueHex = unitPartsIterator->toInt(&hexOk, 16);
@@ -148,7 +148,7 @@ QList<QPair<QString, QString> > MutexKnobData::createUnitReplacementPairList(QSt
                     unitKey += QString(*unitPartsIterator);
                 }
             }
-            for (unitPartsIterator = unitValueParts.begin(); unitPartsIterator < unitValueParts.end(); ++unitPartsIterator) {
+            for (unitPartsIterator = unitValueParts.begin(); unitPartsIterator != unitValueParts.end(); ++unitPartsIterator) {
                 bool hexOk = true;
                 bool decOk = true;
                 quint16 parsedValueHex = unitPartsIterator->toInt(&hexOk, 16);
@@ -871,13 +871,13 @@ void MutexKnobData::UpdateWidget(int index, QWidget* w, char *units, char *fec, 
 
         if (doDefaultUnitReplacements){
             // replace default QStrings
-            for (i = defaultReplaceUnitsPairList.begin(); i < defaultReplaceUnitsPairList.end(); ++i){
+            for (i = defaultReplaceUnitsPairList.begin(); i != defaultReplaceUnitsPairList.end(); ++i){
                 StringUnits.replace(i->first, i->second);
             }
         }
 
         // replace QStrings defined in CAQTDM_REPLACE_UNITS
-        for (i = replaceUnitsPairList.begin(); i < replaceUnitsPairList.end(); ++i){
+        for (i = replaceUnitsPairList.begin(); i != replaceUnitsPairList.end(); ++i){
             StringUnits.replace(i->first, i->second);
         }
 

--- a/caQtDM_Lib/src/mutexKnobData.h
+++ b/caQtDM_Lib/src/mutexKnobData.h
@@ -124,5 +124,7 @@ private:
     bool blockProcess;
 
     UpdateType myUpdateType;
+
+    QMap<QString, QString> replaceUnitsMap;
 };
 #endif // MUTEXKNOBDATA_H

--- a/caQtDM_Lib/src/mutexKnobData.h
+++ b/caQtDM_Lib/src/mutexKnobData.h
@@ -125,6 +125,10 @@ private:
 
     UpdateType myUpdateType;
 
-    QMap<QString, QString> replaceUnitsMap;
+    bool doDefaultUnitReplacements;
+    QList<QPair<QString,QString>> createUnitReplacementPairList(QStringList replaceUnitsList);
+    QList<QPair<QString,QString>> defaultReplaceUnitsPairList;
+    QList<QPair<QString,QString>> replaceUnitsPairList;
+    QStringList createUnitReplacementList();
 };
 #endif // MUTEXKNOBDATA_H

--- a/caQtDM_Lib/src/mutexKnobData.h
+++ b/caQtDM_Lib/src/mutexKnobData.h
@@ -41,6 +41,7 @@
 #include <QObject>
 #include <QVector>
 #include <QMap>
+#include <QPair>
 #include <QWaitCondition>
 #include "knobData.h"
 #include "mutexKnobDataWrapper.h"
@@ -126,9 +127,9 @@ private:
     UpdateType myUpdateType;
 
     bool doDefaultUnitReplacements;
-    QList<QPair<QString,QString>> createUnitReplacementPairList(QStringList replaceUnitsList);
-    QList<QPair<QString,QString>> defaultReplaceUnitsPairList;
-    QList<QPair<QString,QString>> replaceUnitsPairList;
+    QList<QPair<QString,QString> > createUnitReplacementPairList(QStringList replaceUnitsList);
+    QList<QPair<QString,QString> > defaultReplaceUnitsPairList;
+    QList<QPair<QString,QString> > replaceUnitsPairList;
     QStringList createUnitReplacementList();
 };
 #endif // MUTEXKNOBDATA_H

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -504,6 +504,13 @@ FileOpenWindow::FileOpenWindow(QMainWindow* parent,  QString filename, QString m
     this->ui.reloadAction->setEnabled(false);
     }
 
+    // Inform user about CAQTDM_REPLACE_UNITS replacements.
+    if(messageWindow != (MessageWindow *) Q_NULLPTR) {
+        QString replaceUnits = QString(qgetenv("CAQTDM_REPLACE_UNITS"));
+        if(replaceUnits.trimmed().length() > 0) messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is defined.")));
+        else messageWindow->postMsgEvent(QtInfoMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is not defined, standard unit replacements are taking place. You can define \"CAQTDM_REPLACE_UNITS\" to replace characters within or whole units.")));
+    }
+
     // load the control plugins (must be done after setting the environment)
     loadPlugins loadplugins;
     if (!loadplugins.loadAll(interfaces, mutexKnobData, messageWindow, OptionList )) {

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -506,6 +506,9 @@ FileOpenWindow::FileOpenWindow(QMainWindow* parent,  QString filename, QString m
 
     // Inform user about CAQTDM_REPLACE_UNITS replacements.
     if(messageWindow != (MessageWindow *) Q_NULLPTR) {
+    bool doDefaultUnitReplacements = !(qgetenv("CAQTDM_DEFAULT_UNIT_REPLACEMENTS").toLower().replace("\"","") == "false");
+        if (doDefaultUnitReplacements)  messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Default unit replacements are taking place, you can disable them by setting the environment variable \"CAQTDM_DEFAULT_UNIT_REPLACEMENTS\" to false.")));
+        else messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Default unit replacements are disabled by user, you can enable them by unsetting the environment variable \"CAQTDM_DEFAULT_UNIT_REPLACEMENTS\" or setting it to true.")));
         QString replaceUnits = QString(qgetenv("CAQTDM_REPLACE_UNITS"));
         if(replaceUnits.trimmed().length() > 0) messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is defined.")));
         else messageWindow->postMsgEvent(QtInfoMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is not defined, standard unit replacements are taking place. You can define \"CAQTDM_REPLACE_UNITS\" to replace characters within or whole units.")));

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -509,9 +509,9 @@ FileOpenWindow::FileOpenWindow(QMainWindow* parent,  QString filename, QString m
     bool doDefaultUnitReplacements = !(qgetenv("CAQTDM_DEFAULT_UNIT_REPLACEMENTS").toLower().replace("\"","") == "false");
         if (doDefaultUnitReplacements)  messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Default unit replacements are taking place, you can disable them by setting the environment variable \"CAQTDM_DEFAULT_UNIT_REPLACEMENTS\" to false.")));
         else messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Default unit replacements are disabled by user, you can enable them by unsetting the environment variable \"CAQTDM_DEFAULT_UNIT_REPLACEMENTS\" or setting it to true.")));
-        QString replaceUnits = QString(qgetenv("CAQTDM_REPLACE_UNITS"));
-        if(replaceUnits.trimmed().length() > 0) messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is defined.")));
-        else messageWindow->postMsgEvent(QtInfoMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_REPLACE_UNITS\" is not defined, standard unit replacements are taking place. You can define \"CAQTDM_REPLACE_UNITS\" to replace characters within or whole units.")));
+        QString replaceUnits = QString(qgetenv("CAQTDM_CUSTOM_UNIT_REPLACEMENTS"));
+        if(replaceUnits.trimmed().length() > 0) messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_CUSTOM_UNIT_REPLACEMENTS\" is defined.")));
+        else messageWindow->postMsgEvent(QtWarningMsg, (char*) qasc(QString("Info: Environment variable \"CAQTDM_CUSTOM_UNIT_REPLACEMENTS\" is not defined, standard unit replacements are taking place. You can define \"CAQTDM_CUSTOM_UNIT_REPLACEMENTS\" to replace characters within or whole units.")));
     }
 
     // load the control plugins (must be done after setting the environment)


### PR DESCRIPTION
I cleaned up the special character support in units in a more readable way and added the possibility to manually define Characters to be replaced in units. Tested on QT4, 5, 6, Linux and Windows.