### PR TITLE
Fixed error message if file does not exist

### DIFF
--- a/caQtDM_QtControls/src/catextentry.cpp
+++ b/caQtDM_QtControls/src/catextentry.cpp
@@ -113,7 +113,13 @@ bool caTextEntry::eventFilter(QObject *obj, QEvent *event)
         } else {
             QApplication::restoreOverrideCursor();
         }
-        this->activateWindow();  // I added this for ios while I could not get the focus
+
+// The following workaround is only done on mobile as it isn't needed on desktop and only has unwanted side effects,
+// such as the widget getting the focus while another application is focused, only by hovering over it with the mouse cursor.
+#ifdef MOBILE
+            this->activateWindow();  // I added this for ios while I could not get the focus
+#endif
+
     } else if(event->type() == QEvent::Leave) {
         QApplication::restoreOverrideCursor();
         setReadOnly(false);

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -1251,7 +1251,7 @@ void FileOpenWindow::Callback_OpenNewFile(const QString& inputFile, const QStrin
     searchFile *s = new searchFile(FileName);
     QString fileNameFound = s->findFile();
     if(fileNameFound.isNull()) {
-        QString message = QString(FileName);
+        QString message = inputFile;
         message.append(" does not exist");
         QTDMMessageBox *m = new QTDMMessageBox(QMessageBox::Warning, "file open error", message, ":/caQtDM-logos.png", QMessageBox::Close, this, Qt::Dialog| Qt::Popup, true);
         m->show();


### PR DESCRIPTION
Before, if a file without an extension was provided to caQtDM, and it didn't exist, the error message "XY does not exist" had no value for XY, no matter what the provided filename was, because it didn't use the originally provided filename but rather a copy of it which had already been modified, in this case making it empty. I fixed the error message by using the originally provided filename instead of the modified one.