### PR TITLE
Updated CleanAll Scripts for Linux and Windows

### DIFF
--- a/caQtDM_CleanAll
+++ b/caQtDM_CleanAll
@@ -2,13 +2,13 @@
 
 source caQtDM_Env
 
-echo package will be removed from ./caQtDM_Binaries and all directories will be cleaned up
+echo caQtDM_Binaries and all directories will be cleaned up
 
 read -p "Press [Enter] key to start cleanup "
 
 echo ========== remove binaries from directories ============
 if [ -d "./caQtDM_Binaries" ]; then
-rm -rf ./caQtDM_Binaries/*
+rm -rf ./caQtDM_Binaries
 fi
 
 echo ========== remove makefiles from directories ============
@@ -38,6 +38,8 @@ rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archivePRO/Makefile.csplugins
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archivePRO/Makefile
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHIPA/Makefile.csplugins
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHIPA/Makefile
+rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHTTP/Makefile.csplugins
+rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHTTP/Makefile
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveCA/Makefile.csplugins
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveCA/Makefile
 rm -f ./caQtDM_QtControls/Makefile
@@ -83,6 +85,8 @@ rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveSF/obj/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveSF/moc/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHIPA/obj/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHIPA/moc/*
+rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHTTP/obj/*
+rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveHTTP/moc/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archivePRO/obj/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archivePRO/moc/*
 rm -f ./caQtDM_Lib/caQtDM_Plugins/archive/archiveCA/obj/*

--- a/caQtDM_CleanAll
+++ b/caQtDM_CleanAll
@@ -2,13 +2,13 @@
 
 source caQtDM_Env
 
-echo caQtDM_Binaries and all directories will be cleaned up
+echo  $CAQTDM_COLLECT will be removed and all directories will be cleaned up
 
 read -p "Press [Enter] key to start cleanup "
 
 echo ========== remove binaries from directories ============
-if [ -d "./caQtDM_Binaries" ]; then
-rm -rf ./caQtDM_Binaries
+if [ -d "$CAQTDM_COLLECT" ]; then
+rm -rf $CAQTDM_COLLECT
 fi
 
 echo ========== remove makefiles from directories ============

--- a/caQtDM_CleanAll.bat
+++ b/caQtDM_CleanAll.bat
@@ -7,7 +7,7 @@ call caQtDM_Env.bat
 
 set PATH=%PATH%;%QTHOME%\bin
 
-echo package will be removed from .\caQtDM_Binaries and all directories will be cleaned up
+echo .\caQtDM_Binaries(_64Bit) will be removed and all directories will be cleaned up
 
 echo Press [Enter] key to start cleanup
 :clean
@@ -15,6 +15,8 @@ echo ========== remove binaries from directories ============
 qmake all.pro
 where /q jom.exe 
 IF %ERRORLEVEL% NEQ 0 (nmake clean) ELSE (jom clean)
+rmdir /S /Q .\caQtDM_Binaries
+rmdir /S /Q .\caQtDM_Binaries_64Bit
 
 
 echo ========== remove makefiles from directories ============
@@ -39,6 +41,7 @@ del .\caQtDM_Lib\caQtDM_Plugins\environment\Makefile*
 del .\caQtDM_Lib\caQtDM_Plugins\archive\Makefile*
 del .\caQtDM_Lib\caQtDM_Plugins\archive\archiveSF\Makefile*
 del .\caQtDM_Lib\caQtDM_Plugins\archive\archiveHIPA\Makefile*
+del .\caQtDM_Lib\caQtDM_Plugins\archive\archiveHTTP\Makefile*
 del .\caQtDM_Lib\caQtDM_Plugins\archive\archivePro\Makefile*
 
 del .\caQtDM_Parsers\Makefile*
@@ -78,6 +81,10 @@ rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\epics4\release
 rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\epics4\debug
 rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\epics4\moc
 
+rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\archive\archiveHTTP\release
+rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\archive\archiveHTTP\debug
+rmdir /S /Q .\caQtDM_Lib\caQtDM_Plugins\archive\archiveHTTP\moc
+
 rmdir /S /Q .\caQtDM_Parsers\adlParserSharedLib\release
 rmdir /S /Q .\caQtDM_Parsers\adlParserSharedLib\debug
 rmdir /S /Q .\caQtDM_Parsers\adlParserSharedLib\moc
@@ -92,8 +99,6 @@ rmdir /S /Q .\caQtDM_QtControls\moc
 
 rmdir /S /Q .\caQtDM_QtControls\plugins\release
 rmdir /S /Q .\caQtDM_QtControls\plugins\debug
-
-rem rmdir /S /Q .\caQtDM_Binaries
 
 echo =========== remove package files ==================
 

--- a/caQtDM_CleanAll.bat
+++ b/caQtDM_CleanAll.bat
@@ -7,7 +7,7 @@ call caQtDM_Env.bat
 
 set PATH=%PATH%;%QTHOME%\bin
 
-echo .\caQtDM_Binaries(_64Bit) will be removed and all directories will be cleaned up
+echo %CAQTDM_COLLECT% will be removed and all directories will be cleaned up
 
 echo Press [Enter] key to start cleanup
 :clean
@@ -15,8 +15,7 @@ echo ========== remove binaries from directories ============
 qmake all.pro
 where /q jom.exe 
 IF %ERRORLEVEL% NEQ 0 (nmake clean) ELSE (jom clean)
-rmdir /S /Q .\caQtDM_Binaries
-rmdir /S /Q .\caQtDM_Binaries_64Bit
+rmdir /S /Q %CAQTDM_COLLECT%
 
 
 echo ========== remove makefiles from directories ============


### PR DESCRIPTION
I updated the CleanAll Scripts to also delete Files from archiveHTTP and to completely delete caQtDM_Binaries, as otherwise it has already led to problems with plugins not being deleted and so on. And because caQtDM_Binaries is not present in Github, I figured it is okay to delete it entirely.
I tested on Linux (RH8, RH7) and Windows. I tested that the clean / build scripts still work, that the files I want to delete are correctly deleted and that after a build following the new clean, all files / plugins are still built correctly. On Linux, the directories are immediately created again in the cleaning process but empty, which is why it might look like it doesnt work there, but it does.

I did NOT test on MacOS (but it should work)