### PR TITLE
Fixed uninitialized memory issues and added warning for invalid channel limits

### DIFF
--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -5576,12 +5576,18 @@ void CaQtDM_Lib::Callback_UpdateWidget(int indx, QWidget *w,
                     if(data.edata.lower_disp_limit != data.edata.upper_disp_limit) {
                         cartesianplotWidget->setScaleX(data.edata.lower_disp_limit, data.edata.upper_disp_limit);
                     } else {
+                        char asc[MAX_STRING_LENGTH];
+                        snprintf(asc, MAX_STRING_LENGTH, "PV <%s> (x axis) in widget <%s> is set to channel scaling, but the channel limits are invalid. Therefore, the x axis scaling for the widget is reset to auto.", data.pv, qasc(w->objectName()));
+                        postMessage(QtFatalMsg, asc);
                         cartesianplotWidget->setXscaling(caCartesianPlot::Auto);
                     }
                 } else if(XorY == caCartesianPlot::CH_Y && cartesianplotWidget->getYscaling() == caCartesianPlot::Channel) {
                     if(data.edata.lower_disp_limit != data.edata.upper_disp_limit) {
                         cartesianplotWidget->setScaleY(data.edata.lower_disp_limit, data.edata.upper_disp_limit);
                     } else {
+                        char asc[MAX_STRING_LENGTH];
+                        snprintf(asc, MAX_STRING_LENGTH, "PV <%s> (y axis) in widget <%s> is set to channel scaling, but the channel limits are invalid. Therefore, the y axis scaling for the widget is reset to auto.", data.pv, qasc(w->objectName()));
+                        postMessage(QtFatalMsg, asc);
                         cartesianplotWidget->setYscaling(caCartesianPlot::Auto);
                     }
                 }
@@ -7656,6 +7662,11 @@ void CaQtDM_Lib::DisplayContextMenu(QWidget* w)
             } else if(caCartesianPlot* cartesianplotWidget = qobject_cast<caCartesianPlot *>(w)) {
                 limitsCartesianplotDialog dialog(cartesianplotWidget, mutexKnobDataP, "cartesianplot modifications", this);
                 dialog.exec();
+                if (dialog.getChannelScalingWasReset()) {
+                   char asc[MAX_STRING_LENGTH];
+                   snprintf(asc, MAX_STRING_LENGTH, "Selected scaling \"channel\" has been reset to \"auto\" in cartesian plot: \"%s\" because the limits provided by the PV are invalid.", qasc(cartesianplotWidget->objectName()));
+                   postMessage(QtFatalMsg, asc);
+                }
             }
         } else if(selectedItem->text().contains(RESETZOOM)) {
             if(caCartesianPlot* cartesianplotWidget = qobject_cast<caCartesianPlot *>(w)) {

--- a/caQtDM_Lib/src/limitsCartesianplotDialog.cpp
+++ b/caQtDM_Lib/src/limitsCartesianplotDialog.cpp
@@ -28,6 +28,8 @@
 
 limitsCartesianplotDialog::limitsCartesianplotDialog(caCartesianPlot *w, MutexKnobData *data, const QString &title, QWidget *parent) : QWidget(parent)
 {
+    m_channelScalingWasReset = false;
+
     bool ok1, ok2;
     QString xmin, xmax,  ymin, ymax;
     int thisWidth = 650;
@@ -272,6 +274,7 @@ void limitsCartesianplotDialog::applyClicked()
                 } else {
                     //qDebug() << "set to auto";
                     CartesianPlot->setXscaling(caCartesianPlot::Auto);
+                    m_channelScalingWasReset = true;
                 }
              }
         }
@@ -299,6 +302,7 @@ void limitsCartesianplotDialog::applyClicked()
                 } else {
                     //qDebug() << "set to auto";
                     CartesianPlot->setYscaling(caCartesianPlot::Auto);
+                    m_channelScalingWasReset = true;
                 }
              }
         }

--- a/caQtDM_Lib/src/limitsCartesianplotDialog.h
+++ b/caQtDM_Lib/src/limitsCartesianplotDialog.h
@@ -68,6 +68,9 @@
 
      limitsCartesianplotDialog(caCartesianPlot *w, MutexKnobData *data, const QString &title, QWidget *parent);
      void exec();
+     bool getChannelScalingWasReset() {
+         return m_channelScalingWasReset;
+     };
 
  public slots:
      void cancelClicked();
@@ -92,6 +95,7 @@
      MutexKnobData *monData;
      QDialogButtonBox *buttonBox;
      QEventLoop loop;
+     bool m_channelScalingWasReset;
  };
 
 

--- a/caQtDM_QtControls/src/cacartesianplot.cpp
+++ b/caQtDM_QtControls/src/cacartesianplot.cpp
@@ -44,6 +44,9 @@ caCartesianPlot::caCartesianPlot(QWidget *parent) : QwtPlot(parent)
 
     thisToBeTriggered = false;
     thisTriggerNow = true;
+    thisTriggerPV = "";
+    thisErasePV = "";
+    thisCountPV = "";
     thisCountNumber = 0;
     thisXaxisSyncGroup = 0;
     thisXticks = 5;
@@ -147,9 +150,11 @@ caCartesianPlot::caCartesianPlot(QWidget *parent) : QwtPlot(parent)
     setColor_5(Qt::green);
     setColor_6(Qt::magenta);
 
-    thisLegendshow = false;
+    setLegendEnabled(false);
     setXaxisEnabled(true);
     setYaxisEnabled(true);
+    setXaxisType(axisType::linear);
+    setYaxisType(axisType::linear);
     setXscaling(Auto);
     setYscaling(Auto);
     setXaxisLimits("0;1");


### PR DESCRIPTION
I initialized some variables in caCartesianPlot previously uninitialized, leading to ambigous behaviour.
Also added an error message in case the user tries to specify channel limits (either in the UI file or using the "change axis" menu).