### PR TITLE
Fix user defined formats for caLineEdit 

### DIFF
--- a/caQtDM_QtControls/src/calineedit.cpp
+++ b/caQtDM_QtControls/src/calineedit.cpp
@@ -434,7 +434,10 @@ void caLineEdit::setValue(double value, const QString& units)
       } else {
         snprintf(asc, MAX_STRING_LENGTH, thisFormat, value);
       }
-    } else if(thisFormatType == hexadecimal || thisFormatType == octal || thisFormatType == user_defined_format)  {
+    } else if (thisFormatType == user_defined_format) {
+        if(thisDatatype == caDOUBLE) snprintf(asc, MAX_STRING_LENGTH, thisFormat, value);
+        else snprintf(asc, MAX_STRING_LENGTH, thisFormat, (int) value);
+    } else if(thisFormatType == hexadecimal || thisFormatType == octal)  {
         if(thisDatatype == caDOUBLE) snprintf(asc, MAX_STRING_LENGTH, thisFormat, (long long) value);
         else  snprintf(asc, MAX_STRING_LENGTH, thisFormat, (int) value);
     } else if(thisFormatType == truncated) {

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -1237,7 +1237,7 @@ is the equivalent of the Text Update in MEDM.
       |                                  | absolaute precision from user or |
       |                                  | channel                          |
       +----------------------------------+----------------------------------+
-      | compact                          | value encode in e or f format    |
+      | compact                          | value encoded in e or f format   |
       |                                  | using absolaute precision from   |
       |                                  | user or channel, format will     |
       |                                  | switch to e format for values    |
@@ -1254,6 +1254,11 @@ is the equivalent of the Text Update in MEDM.
       +----------------------------------+----------------------------------+
       | string                           | will be treated as decimal       |
       |                                  | format                           |
+      +----------------------------------+----------------------------------+
+      | user_defined_format              | takes a c printf style format    |
+      |                                  | string taking a float if the     |
+      |                                  | channel has the type of double   |
+      |                                  | and an int if not                |
       +----------------------------------+----------------------------------+
 
 --------------
@@ -1584,7 +1589,7 @@ curves
       when either one changes, in the case of X, Y Scalar) a new point
       is plotted until there are Count points. The points are plotted
       from i = 0 to the lesser of Count -1 and the number of updates.
-      When the Plot Mode is "PlotNPointsAndStop",ù no more points are
+      When the Plot Mode is "PlotNPointsAndStop",¬ù no more points are
       plotted. When the Plot Mode is "PlotLastNPoints", the earliest point
       is discarded and the others are moved down, and the latest is
       plotted at the end. In the cases where one of the process
@@ -2806,7 +2811,7 @@ other string, both on the command line and when calling a `related
 display <#RelatedDisplay>`__. Specific directions for each of these
 cases are given in the correspoonding sections of the manual. In
 general, there is an argument string with the form
-``name1=value1[,name2=value2]...``.  All occurrences of "(name1)"ù in the
+``name1=value1[,name2=value2]...``.  All occurrences of "(name1)"¬ù in the
 ``.ui`` file are replaced with "value1", then all occurences of $(name2)
 are replaced by value2, *etc*. The substitition is recursive; that is,
 if value1 contains an occurrence of $(name2), then when name2=value2
@@ -2964,7 +2969,7 @@ You have to first write the source characters you want to replace, then an equal
 character replacements, seperate them by semicolon (;). Parts that dont contain an equal sign but are seperated from other parts with semicolon are ignored. All put together this would be the structure:
 CAQTDM_CUSTOM_UNIT_REPLACEMENTS={sourceCharacters}={replacementCharacters};{anotherReplacement}
 An example (that doesnt make much sense but displays many possibilities) would be:
-CAQTDM_CUSTOM_UNIT_REPLACEMENTS=charsToReplace=charsToUse;0x48,0x68=bye;charsWithHex,0x4f=something;∞=o
+CAQTDM_CUSTOM_UNIT_REPLACEMENTS=charsToReplace=charsToUse;0x48,0x68=bye;charsWithHex,0x4f=something;¬∞=o
 It can be seen that all combinations of strings, hex- and deciaml character codes are possible to form a source or replacement string.
 All replacements will be done sequentially, with the leftmost replacements being done first. Therefore, it can also be possible, that later replacements replace characters in a string
 that has already been replaced before by another replacements.


### PR DESCRIPTION
Issue: if you define a custom format string for displaying a channel in a caLineEdit and the channel value is a double it is cast to a long long before passing it to snprintf.

Proposed fix: Treat user_defined_format separately form hexadecimal and octal formats and skip the cast if the type is double.

This is only a band-aid fix for the custom format strings as a proper implementation would do some kind of input validation. As it currently stands the user can easily crash caQtDM by including for example a %s in the format string. There is also no feedback to the user if the specified format string takes a data type different from what was expected.

I also updated the documentation to include the user_defined_format. 
(the diff shows some changes at '@@ -1584,7 +1589,7 @@ curves'. I think that this is probably something to do with line endings and my editor automatically changing them)

Best,

Joschka