### PR TITLE
Updating the functionality of the caLineDraw-Copying

### DIFF
--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6704,6 +6704,7 @@ void CaQtDM_Lib::Callback_ScriptButton()
 }
 
 void CaQtDM_Lib::Callback_CopyMarked(){
+    setFocus(Qt::MouseFocusReason);
     QString copyString;
     int markedCount = 0;
     QClipboard *clipboard = QApplication::clipboard();
@@ -6711,19 +6712,32 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     QList lineDrawList = findChildren<caLineDraw *>();
 
     for(int i = 0; i <= lineDrawList.length() -1; i++){
-        if(lineDrawList[i]->getMarkAll() == true && (lineDrawList[i]->getText().length() > 0)){
-            copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
+        if(lineDrawList[i]->getMarkedText().length() > 0){
+            if(lineDrawList[i]->getMarkAll() == true){
+                copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
+            }
+
             markedCount++;
-        }else if(lineDrawList[i]->getMarkedText().length() > 0){
-            copyString = lineDrawList[i]->getMarkedText();
-            break;
         }
     }
 
+    if(markedCount == 1){
+        qDebug() << markedCount;
+        copyString = copyString.split("\t")[1].replace("\n", QString(""));
+    }
+
     // Copy to Clipboard
-    if(copyString.size() > 0 && markedCount >= 2){
+    if(copyString.size() > 0){
         clipboard->setText(copyString);
     }
+
+    // CaTextentry inherits from caLineEdit
+    QList lle = findChildren<caLineEdit *>();
+    for(int i = 0; i <= lle.length() -1; i++){
+   //     qDebug() << lle[i]->selectedText() << lle[i]->getPV();
+    }
+    qDebug() << copyString;
+    clearFocus();
 }
 
 void CaQtDM_Lib::processTerminated()

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6721,6 +6721,10 @@ void CaQtDM_Lib::Callback_CopyMarked(){
         table->copy();
     }
 
+    caMultiLineString *multiline = qobject_cast<caMultiLineString *>(widg);
+    if(multiline){
+        multiline->copy();
+    }
 
 }
 

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6707,24 +6707,16 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     QWidget *widg = QApplication::focusWidget();
 
     caLineDraw *draw = qobject_cast<caLineDraw *>(widg);
-    if(draw){
-        draw->copy();
-    }
+    if(draw){ draw->copy(); }
 
     caWaveTable *wavetable = qobject_cast<caWaveTable *>(widg);
-    if(wavetable){
-        wavetable->copy();
-    }
+    if(wavetable){ wavetable->copy(); }
 
     caTable *table = qobject_cast<caTable *>(widg);
-    if(table){
-        table->copy();
-    }
+    if(table){ table->copy(); }
 
     caMultiLineString *multiline = qobject_cast<caMultiLineString *>(widg);
-    if(multiline){
-        multiline->copy();
-    }
+    if(multiline){ multiline->copy(); }
 
 }
 

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6704,33 +6704,11 @@ void CaQtDM_Lib::Callback_ScriptButton()
 }
 
 void CaQtDM_Lib::Callback_CopyMarked(){
-    QClipboard *clipboard = QApplication::clipboard();
     QWidget *widg = QApplication::focusWidget();
-    QString copyString;
 
     caLineDraw *draw = qobject_cast<caLineDraw *>(widg);
     if(draw){
-        int markedCount = 0;
-        QList lineDrawList = findChildren<caLineDraw *>();
-        for(int i = 0; i <= lineDrawList.length() -1; i++){
-            if(lineDrawList[i]->getMarkedText().length() > 0){
-                if(lineDrawList[i]->getMarkAll() == true){
-                    copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
-                }
-
-                markedCount++;
-            }
-        }
-
-        if(markedCount == 1){
-            qDebug() << markedCount;
-            copyString = copyString.split("\t")[1].replace("\n", QString(""));
-        }
-
-        // Copy to Clipboard
-        if(copyString.size() > 0){
-            clipboard->setText(copyString);
-        }
+        draw->copy();
     }
 
     caWaveTable *wavetable = qobject_cast<caWaveTable *>(widg);

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6707,11 +6707,32 @@ void CaQtDM_Lib::Callback_ScriptButton()
 }
 
 void CaQtDM_Lib::clearSelection(){
-    clearCaLineDraw();
-    clearCaMultiLineString();
-    clearCaLineEdit();
-    clearCaWaveTable();
-    clearCaTable();
+
+    QList<caLineDraw *> drawChild = parent()->findChildren<caLineDraw *>();
+    foreach(caLineDraw *ld, drawChild){
+        ld->clearSelection();
+    }
+
+    QList<caLineEdit *> editChild = parent()->findChildren<caLineEdit *>();
+    foreach(caLineEdit *le, editChild){
+        le->setSelection(0,0);
+    }
+
+    QList<caMultiLineString *> multiChild = parent()->findChildren<caMultiLineString *>();
+    foreach(caMultiLineString *mls, multiChild){
+        mls->clearSelection();
+    }
+
+    QList<caWaveTable *> waveChild = parent()->findChildren<caWaveTable *>();
+    foreach(caWaveTable *wt, waveChild){
+        wt->clearSelection();
+    }
+
+    QList<caTable *> tableChild = parent()->findChildren<caTable *>();
+
+    foreach(caTable *tt, tableChild){
+        tt->clearSelection();
+    }
 }
 
 void CaQtDM_Lib::Callback_CopyMarked(){
@@ -6731,40 +6752,6 @@ void CaQtDM_Lib::Callback_CopyMarked(){
 
     caLineEdit *lineedit = qobject_cast<caLineEdit *>(widg);
     if(lineedit){ lineedit->copy(); }
-}
-
-void CaQtDM_Lib::clearCaLineDraw(){
-    QList<caLineDraw *> drawChild = parent()->findChildren<caLineDraw *>();
-    foreach(caLineDraw *ld, drawChild){
-        ld->clearSelection();
-    }
-
-}
-void CaQtDM_Lib::clearCaLineEdit(){
-    QList<caLineEdit *> editChild = parent()->findChildren<caLineEdit *>();
-    foreach(caLineEdit *le, editChild){
-        le->setSelection(0,0);
-    }
-}
-void CaQtDM_Lib::clearCaMultiLineString(){
-    QList<caMultiLineString *> multiChild = parent()->findChildren<caMultiLineString *>();
-    foreach(caMultiLineString *mls, multiChild){
-        mls->clearSelection();
-    }
-}
-void CaQtDM_Lib::clearCaWaveTable(){
-    QList<caWaveTable *> waveChild = parent()->findChildren<caWaveTable *>();
-
-    foreach(caWaveTable *wt, waveChild){
-        wt->clearSelection();
-    }
-}
-void CaQtDM_Lib::clearCaTable(){
-    QList<caTable *> tableChild = parent()->findChildren<caTable *>();
-
-    foreach(caTable *tt, tableChild){
-        tt->clearSelection();
-    }
 }
 
 void CaQtDM_Lib::processTerminated()

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6709,28 +6709,42 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     caLineDraw *draw = qobject_cast<caLineDraw *>(widg);
     if(draw){
         draw->copy();
+
+        clearCaMultiLineString();
+        clearcaLineEdit();
+        clearCaWaveTable();
+        clearCaTable();
     }
 
     caWaveTable *wavetable = qobject_cast<caWaveTable *>(widg);
     if(wavetable){
         wavetable->copy();
+
+        clearCaLineDraw();
+        clearCaMultiLineString();
+        clearcaLineEdit();
+        clearCaTable();
     }
 
     caTable *table = qobject_cast<caTable *>(widg);
     if(table){
         table->copy();
+
+        clearCaLineDraw();
+        clearCaMultiLineString();
+        clearcaLineEdit();
+        clearCaWaveTable();
     }
 
     caMultiLineString *multiline = qobject_cast<caMultiLineString *>(widg);
     if(multiline){
         multiline->copy();
-    }
 
-    clearCaLineDraw();
-    clearCaMultiLineString();
-    clearcaLineEdit();
-    clearCaWaveTable();
-    clearCaTable();
+        clearCaLineDraw();
+        clearcaLineEdit();
+        clearCaWaveTable();
+        clearCaTable();
+    }
 }
 
 void CaQtDM_Lib::clearCaLineDraw(){

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6725,17 +6725,32 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     if(multiline){
         multiline->copy();
     }
+
+    clearCaLineDraw();
+    clearCaMultiLineString();
+    clearcaLineEdit();
+    clearCaWaveTable();
+    clearCaTable();
 }
 
 void CaQtDM_Lib::clearCaLineDraw(){
     QList<caLineDraw *> drawChild = parent()->findChildren<caLineDraw *>();
+    foreach(caLineDraw *ld, drawChild){
+        ld->clearSelection();
+    }
 
 }
 void CaQtDM_Lib::clearcaLineEdit(){
     QList<caLineEdit *> editChild = parent()->findChildren<caLineEdit *>();
+    foreach(caLineEdit *le, editChild){
+        le->setSelection(0,0);
+    }
 }
 void CaQtDM_Lib::clearCaMultiLineString(){
     QList<caMultiLineString *> multiChild = parent()->findChildren<caMultiLineString *>();
+    foreach(caMultiLineString *mls, multiChild){
+        mls->clearSelection();
+    }
 }
 void CaQtDM_Lib::clearCaWaveTable(){
     QList<caWaveTable *> waveChild = parent()->findChildren<caWaveTable *>();

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6707,17 +6707,49 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     QWidget *widg = QApplication::focusWidget();
 
     caLineDraw *draw = qobject_cast<caLineDraw *>(widg);
-    if(draw){ draw->copy(); }
+    if(draw){
+        draw->copy();
+    }
 
     caWaveTable *wavetable = qobject_cast<caWaveTable *>(widg);
-    if(wavetable){ wavetable->copy(); }
+    if(wavetable){
+        wavetable->copy();
+    }
 
     caTable *table = qobject_cast<caTable *>(widg);
-    if(table){ table->copy(); }
+    if(table){
+        table->copy();
+    }
 
     caMultiLineString *multiline = qobject_cast<caMultiLineString *>(widg);
-    if(multiline){ multiline->copy(); }
+    if(multiline){
+        multiline->copy();
+    }
+}
 
+void CaQtDM_Lib::clearCaLineDraw(){
+    QList<caLineDraw *> drawChild = parent()->findChildren<caLineDraw *>();
+
+}
+void CaQtDM_Lib::clearcaLineEdit(){
+    QList<caLineEdit *> editChild = parent()->findChildren<caLineEdit *>();
+}
+void CaQtDM_Lib::clearCaMultiLineString(){
+    QList<caMultiLineString *> multiChild = parent()->findChildren<caMultiLineString *>();
+}
+void CaQtDM_Lib::clearCaWaveTable(){
+    QList<caWaveTable *> waveChild = parent()->findChildren<caWaveTable *>();
+
+    foreach(caWaveTable *wt, waveChild){
+        wt->clearSelection();
+    }
+}
+void CaQtDM_Lib::clearCaTable(){
+    QList<caTable *> tableChild = parent()->findChildren<caTable *>();
+
+    foreach(caTable *tt, tableChild){
+        tt->clearSelection();
+    }
 }
 
 void CaQtDM_Lib::processTerminated()

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -692,6 +692,9 @@ CaQtDM_Lib::CaQtDM_Lib(QWidget *parent, QString filename, QString macro, MutexKn
     QShortcut *CopyMarking = new QShortcut(tr("Ctrl+C"), this);
     connect(CopyMarking, SIGNAL(activated()), this, SLOT(Callback_CopyMarked()));
 
+    // Ctrl+Shift+D was selected arbitrarily -> "Deselect" everything currently marked
+    QShortcut *DeSelect = new QShortcut(tr("Ctrl+Shift+D"), this);
+    connect(DeSelect, SIGNAL(activated()), this, SLOT(clearSelection()));
 
     char asc[MAX_STRING_LENGTH];
     QString path = thisFileFull;
@@ -6703,6 +6706,14 @@ void CaQtDM_Lib::Callback_ScriptButton()
 #endif
 }
 
+void CaQtDM_Lib::clearSelection(){
+    clearCaLineDraw();
+    clearCaMultiLineString();
+    clearCaLineEdit();
+    clearCaWaveTable();
+    clearCaTable();
+}
+
 void CaQtDM_Lib::Callback_CopyMarked(){
     QWidget *widg = QApplication::focusWidget();
 
@@ -6711,7 +6722,7 @@ void CaQtDM_Lib::Callback_CopyMarked(){
         draw->copy();
 
         clearCaMultiLineString();
-        clearcaLineEdit();
+        clearCaLineEdit();
         clearCaWaveTable();
         clearCaTable();
     }
@@ -6722,7 +6733,7 @@ void CaQtDM_Lib::Callback_CopyMarked(){
 
         clearCaLineDraw();
         clearCaMultiLineString();
-        clearcaLineEdit();
+        clearCaLineEdit();
         clearCaTable();
     }
 
@@ -6732,7 +6743,7 @@ void CaQtDM_Lib::Callback_CopyMarked(){
 
         clearCaLineDraw();
         clearCaMultiLineString();
-        clearcaLineEdit();
+        clearCaLineEdit();
         clearCaWaveTable();
     }
 
@@ -6741,9 +6752,19 @@ void CaQtDM_Lib::Callback_CopyMarked(){
         multiline->copy();
 
         clearCaLineDraw();
-        clearcaLineEdit();
+        clearCaLineEdit();
         clearCaWaveTable();
         clearCaTable();
+    }
+
+    caLineEdit *lineedit = qobject_cast<caLineEdit *>(widg);
+    if(lineedit){
+        lineedit->copy();
+
+        clearCaLineDraw();
+        clearCaWaveTable();
+        clearCaTable();
+        clearCaMultiLineString();
     }
 }
 
@@ -6754,7 +6775,7 @@ void CaQtDM_Lib::clearCaLineDraw(){
     }
 
 }
-void CaQtDM_Lib::clearcaLineEdit(){
+void CaQtDM_Lib::clearCaLineEdit(){
     QList<caLineEdit *> editChild = parent()->findChildren<caLineEdit *>();
     foreach(caLineEdit *le, editChild){
         le->setSelection(0,0);

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -692,8 +692,8 @@ CaQtDM_Lib::CaQtDM_Lib(QWidget *parent, QString filename, QString macro, MutexKn
     QShortcut *CopyMarking = new QShortcut(tr("Ctrl+C"), this);
     connect(CopyMarking, SIGNAL(activated()), this, SLOT(Callback_CopyMarked()));
 
-    // Ctrl+Shift+D was selected arbitrarily -> "Deselect" everything currently marked
-    QShortcut *DeSelect = new QShortcut(tr("Ctrl+Shift+D"), this);
+    // Ctrl+Alt+D was selected arbitrarily -> "Deselect" everything currently marked
+    QShortcut *DeSelect = new QShortcut(tr("Ctrl+Alt+D"), this);
     connect(DeSelect, SIGNAL(activated()), this, SLOT(clearSelection()));
 
     char asc[MAX_STRING_LENGTH];

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -6718,54 +6718,19 @@ void CaQtDM_Lib::Callback_CopyMarked(){
     QWidget *widg = QApplication::focusWidget();
 
     caLineDraw *draw = qobject_cast<caLineDraw *>(widg);
-    if(draw){
-        draw->copy();
-
-        clearCaMultiLineString();
-        clearCaLineEdit();
-        clearCaWaveTable();
-        clearCaTable();
-    }
+    if(draw){ draw->copy(); }
 
     caWaveTable *wavetable = qobject_cast<caWaveTable *>(widg);
-    if(wavetable){
-        wavetable->copy();
-
-        clearCaLineDraw();
-        clearCaMultiLineString();
-        clearCaLineEdit();
-        clearCaTable();
-    }
+    if(wavetable){ wavetable->copy(); }
 
     caTable *table = qobject_cast<caTable *>(widg);
-    if(table){
-        table->copy();
-
-        clearCaLineDraw();
-        clearCaMultiLineString();
-        clearCaLineEdit();
-        clearCaWaveTable();
-    }
+    if(table){ table->copy(); }
 
     caMultiLineString *multiline = qobject_cast<caMultiLineString *>(widg);
-    if(multiline){
-        multiline->copy();
-
-        clearCaLineDraw();
-        clearCaLineEdit();
-        clearCaWaveTable();
-        clearCaTable();
-    }
+    if(multiline){ multiline->copy(); }
 
     caLineEdit *lineedit = qobject_cast<caLineEdit *>(widg);
-    if(lineedit){
-        lineedit->copy();
-
-        clearCaLineDraw();
-        clearCaWaveTable();
-        clearCaTable();
-        clearCaMultiLineString();
-    }
+    if(lineedit){ lineedit->copy(); }
 }
 
 void CaQtDM_Lib::clearCaLineDraw(){

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -688,6 +688,11 @@ CaQtDM_Lib::CaQtDM_Lib(QWidget *parent, QString filename, QString macro, MutexKn
     connect(ResizeDownAction, SIGNAL(triggered()), this, SLOT(Callback_ResizeDown()));
     this->addAction(ResizeDownAction);
 
+    QAction *CopyMarkedAction = new QAction(this);
+    CopyMarkedAction->setShortcut(QKeySequence(tr("Ctrl+C")));
+    connect(CopyMarkedAction, SIGNAL(triggered()), this, SLOT(Callback_CopyMarked()));
+    this->addAction(CopyMarkedAction);
+
     char asc[MAX_STRING_LENGTH];
     QString path = thisFileFull;
     int pos = path.lastIndexOf("/");
@@ -6696,6 +6701,29 @@ void CaQtDM_Lib::Callback_ScriptButton()
         w->setProcess(t);
     }
 #endif
+}
+
+void CaQtDM_Lib::Callback_CopyMarked(){
+    QString copyString;
+    int markedCount = 0;
+    QClipboard *clipboard = QApplication::clipboard();
+
+    QList lineDrawList = findChildren<caLineDraw *>();
+
+    for(int i = 0; i <= lineDrawList.length() -1; i++){
+        if(lineDrawList[i]->getMarkAll() == true && (lineDrawList[i]->getText().length() > 0)){
+            copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
+            markedCount++;
+        }else if(lineDrawList[i]->getMarkedText().length() > 0){
+            copyString = lineDrawList[i]->getMarkedText();
+            break;
+        }
+    }
+
+    // Copy to Clipboard
+    if(copyString.size() > 0 && markedCount >= 2){
+        clipboard->setText(copyString);
+    }
 }
 
 void CaQtDM_Lib::processTerminated()

--- a/caQtDM_Lib/src/caqtdm_lib.h
+++ b/caQtDM_Lib/src/caqtdm_lib.h
@@ -419,12 +419,6 @@ private:
     QString savedMacro[CAQTDM_MAX_INCLUDE_LEVEL];
     QString savedFile[CAQTDM_MAX_INCLUDE_LEVEL];
 
-    void clearCaLineDraw();
-    void clearCaMultiLineString();
-    void clearCaWaveTable();
-    void clearCaTable();
-    void clearCaLineEdit();
-
 #ifndef MOBILE
     myQProcess *proc;
 #endif

--- a/caQtDM_Lib/src/caqtdm_lib.h
+++ b/caQtDM_Lib/src/caqtdm_lib.h
@@ -423,7 +423,7 @@ private:
     void clearCaMultiLineString();
     void clearCaWaveTable();
     void clearCaTable();
-    void clearcaLineEdit();
+    void clearCaLineEdit();
 
 #ifndef MOBILE
     myQProcess *proc;
@@ -517,6 +517,7 @@ private slots:
 
     void Callback_WriteDetectedValues(QWidget* w);
     void Callback_CopyMarked();
+    void clearSelection();
 
     void Callback_ReloadWindowL() {
 

--- a/caQtDM_Lib/src/caqtdm_lib.h
+++ b/caQtDM_Lib/src/caqtdm_lib.h
@@ -419,6 +419,12 @@ private:
     QString savedMacro[CAQTDM_MAX_INCLUDE_LEVEL];
     QString savedFile[CAQTDM_MAX_INCLUDE_LEVEL];
 
+    void clearCaLineDraw();
+    void clearCaMultiLineString();
+    void clearCaWaveTable();
+    void clearCaTable();
+    void clearcaLineEdit();
+
 #ifndef MOBILE
     myQProcess *proc;
 #endif

--- a/caQtDM_Lib/src/caqtdm_lib.h
+++ b/caQtDM_Lib/src/caqtdm_lib.h
@@ -510,6 +510,7 @@ private slots:
     void handleFileChanged(const QString&);
 
     void Callback_WriteDetectedValues(QWidget* w);
+    void Callback_CopyMarked();
 
     void Callback_ReloadWindowL() {
 

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -321,25 +321,29 @@ void caLineDraw::resetMarking(){
             m_LetterMarkedList << false;
         }
     }
+    update();
 }
 
 void caLineDraw::handleMultipleMarkedObjects(){
     QString copyString;
-    bool isMoreThanOneMarked = false;
+    int markedCount = 0;
 
     QList lineDrawList = (parent()->findChildren<caLineDraw *>());
     qDebug() << "NEW:";
     for(int i = 0; i <= lineDrawList.length() -1; i++){
         if(lineDrawList[i]->m_markAllText == true){
             copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
-            if(i == 1){isMoreThanOneMarked = true;}
+            markedCount++;
+        }else{
+           // lineDrawList[i]->resetMarking();
         }
+        qDebug() << lineDrawList[i]->m_markAllText << markedCount;
     }
     qDebug().noquote() << copyString;
     // Copy to Clipboard
 
     QClipboard *clipboard = QApplication::clipboard();
-    if(copyString.size() > 0 && isMoreThanOneMarked){
+    if(copyString.size() > 0 && markedCount >= 2){
         clipboard->setText(copyString);
     }else{
         clipboard->setText(getMarkedText());
@@ -354,19 +358,21 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
 
         // Reset Marking
         resetMarking();
-
-        QList lineDrawList = (parent()->findChildren<caLineDraw *>());
-        for(int i = 0; i <= lineDrawList.length() -1; i++){
-           // lineDrawList[i]->resetMarking();
-        }
-
-        update();
     }
 
     if(event->buttons() == Qt::LeftButton || event->buttons() == Qt::RightButton){
         setFocus();
-        handleMultipleMarkedObjects();
+    }
+}
 
+void caLineDraw::mouseReleaseEvent(QMouseEvent *event){
+    QList lineDrawList = (parent()->findChildren<caLineDraw *>());
+
+    lineDrawList.removeAt(lineDrawList.indexOf(this));
+    if(!(m_Text == getMarkedText())){
+        for(int i = 0; i <= lineDrawList.size() -1; i++){
+            lineDrawList[i]->resetMarking();
+        }
         update();
     }
 }

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -312,6 +312,17 @@ bool caLineDraw::rotateText(float degrees)
     return false;
 }
 
+void caLineDraw::resetMarking(){
+    m_LetterMarkedList.clear();
+    m_LettersBoundingRects.clear();
+    m_markAllText = false;
+    if(m_Text.size() > 0){
+        for(int i = 0; i <= m_Text.size() ; i++){
+            m_LetterMarkedList << false;
+        }
+    }
+}
+
 void caLineDraw::mousePressEvent(QMouseEvent *event)
 {
     if(event->buttons() == Qt::LeftButton){
@@ -319,13 +330,11 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
         m_MouseClickPosition = calculateCoordinates(event->pos());
 
         // Reset Marking
-        m_LetterMarkedList.clear();
-        m_LettersBoundingRects.clear();
-        m_markAllText = false;
-        if(m_Text.size() > 0){
-            for(int i = 0; i <= m_Text.size() ; i++){
-                m_LetterMarkedList << false;
-            }
+        resetMarking();
+
+        QList l = (parent()->findChildren<caLineDraw *>());
+        for(int i = 0; i <= l.length() -1; i++){
+            l[i]->resetMarking();
         }
 
         update();

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -1046,5 +1046,33 @@ void caLineDraw::getWidgetInfo(QString* pv, int& nbPV, int& limitsDefault, int& 
 
 }
 
+void caLineDraw::copy(){
+    QClipboard *clipboard = QApplication::clipboard();
+    QList lineDrawList = parent()->findChildren<caLineDraw *>();
+
+    QString copyString;
+    int markedCount = 0;
+
+    for(int i = 0; i <= lineDrawList.length() -1; i++){
+        if(lineDrawList[i]->getMarkedText().length() > 0){
+            if(lineDrawList[i]->getMarkAll() == true){
+                copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
+            }
+
+            markedCount++;
+        }
+    }
+
+    if(markedCount == 1){
+        qDebug() << markedCount;
+        copyString = copyString.split("\t")[1].replace("\n", QString(""));
+    }
+
+    // Copy to Clipboard
+    if(copyString.size() > 0){
+        clipboard->setText(copyString);
+    }
+}
+
 
 

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -324,32 +324,6 @@ void caLineDraw::resetMarking(){
     update();
 }
 
-void caLineDraw::handleMultipleMarkedObjects(){
-    QString copyString;
-    int markedCount = 0;
-
-    QList lineDrawList = (parent()->findChildren<caLineDraw *>());
-    qDebug() << "NEW:";
-    for(int i = 0; i <= lineDrawList.length() -1; i++){
-        if(lineDrawList[i]->m_markAllText == true && (lineDrawList[i]->m_Text.length() > 0)){
-            copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
-            markedCount++;
-        }else{
-           // lineDrawList[i]->resetMarking();
-        }
-        qDebug() << lineDrawList[i]->m_markAllText << markedCount;
-    }
-    qDebug().noquote() << copyString;
-    // Copy to Clipboard
-
-    QClipboard *clipboard = QApplication::clipboard();
-    if(copyString.size() > 0 && markedCount >= 2){
-        clipboard->setText(copyString);
-    }else{
-        clipboard->setText(getMarkedText());
-    }
-}
-
 void caLineDraw::mousePressEvent(QMouseEvent *event)
 {
     if(event->buttons() == Qt::LeftButton){
@@ -407,10 +381,6 @@ void caLineDraw::keyPressEvent(QKeyEvent *event){
 
     if(event_modifier == Qt::ControlModifier){
         switch(keyPressed){
-        // CTRL + C
-        case Qt::Key_C:
-            handleMultipleMarkedObjects();
-            break;
         // CTRL + A
         case Qt::Key_A:
             m_markAllText = true;

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -323,6 +323,16 @@ void caLineDraw::resetMarking(){
     }
 }
 
+void caLineDraw::handleMultipleMarkedObjects(){
+    QList lineDrawList = (parent()->findChildren<caLineDraw *>());
+    qDebug() << "NEW:";
+    for(int i = 0; i <= lineDrawList.length() -1; i++){
+        if(lineDrawList[i]->m_markAllText == true){
+            qDebug() << lineDrawList[i]->objectName() << lineDrawList[i]->getPV();
+        }
+    }
+}
+
 void caLineDraw::mousePressEvent(QMouseEvent *event)
 {
     if(event->buttons() == Qt::LeftButton){
@@ -332,9 +342,9 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
         // Reset Marking
         resetMarking();
 
-        QList l = (parent()->findChildren<caLineDraw *>());
-        for(int i = 0; i <= l.length() -1; i++){
-            l[i]->resetMarking();
+        QList lineDrawList = (parent()->findChildren<caLineDraw *>());
+        for(int i = 0; i <= lineDrawList.length() -1; i++){
+           // lineDrawList[i]->resetMarking();
         }
 
         update();
@@ -342,6 +352,9 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
 
     if(event->buttons() == Qt::LeftButton || event->buttons() == Qt::RightButton){
         setFocus();
+        handleMultipleMarkedObjects();
+
+        update();
     }
 }
 
@@ -711,6 +724,10 @@ void caLineDraw::paintEvent(QPaintEvent *)
 
                 painter.drawText(rectangleToDraw,Qt::AlignCenter | Qt::AlignVCenter,  QString(m_Text[i]));
             }
+    }
+
+    if(m_Text == getMarkedText()){
+        m_markAllText = true;
     }
 
     painter.setPen(m_ForeColor);

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -331,7 +331,7 @@ void caLineDraw::handleMultipleMarkedObjects(){
     QList lineDrawList = (parent()->findChildren<caLineDraw *>());
     qDebug() << "NEW:";
     for(int i = 0; i <= lineDrawList.length() -1; i++){
-        if(lineDrawList[i]->m_markAllText == true){
+        if(lineDrawList[i]->m_markAllText == true && (lineDrawList[i]->m_Text.length() > 0)){
             copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
             markedCount++;
         }else{
@@ -355,7 +355,6 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
     if(event->buttons() == Qt::LeftButton){
 
         m_MouseClickPosition = calculateCoordinates(event->pos());
-
         // Reset Marking
         resetMarking();
     }
@@ -368,13 +367,27 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
 void caLineDraw::mouseReleaseEvent(QMouseEvent *event){
     QList lineDrawList = (parent()->findChildren<caLineDraw *>());
 
+    // Remove currently Marked Instance rom list
     lineDrawList.removeAt(lineDrawList.indexOf(this));
-    if(!(m_Text == getMarkedText())){
+
+    QString s = m_Text;
+    if(s[s.length()-1] == QString(" ")){
+        s.removeAt(s.length()-1);
+        qDebug() << s;
+    }
+
+    qDebug() << this->thisPV << m_Text << s;
+    if(s != getMarkedText() && s.length() > 0){
         for(int i = 0; i <= lineDrawList.size() -1; i++){
-            lineDrawList[i]->resetMarking();
+           // lineDrawList[i]->resetMarking();
         }
         update();
     }
+}
+
+void caLineDraw::mouseDoubleClickEvent(QMouseEvent *event){
+    m_markAllText = true;
+    update();
 }
 
 void caLineDraw::mouseMoveEvent(QMouseEvent *event){
@@ -403,6 +416,13 @@ void caLineDraw::keyPressEvent(QKeyEvent *event){
             m_markAllText = true;
             update();
             break;
+        }
+    }
+
+    if(keyPressed == Qt::Key_Escape){
+        QList lineDrawList = (parent()->findChildren<caLineDraw *>());
+        for(int i = 0; i <= lineDrawList.size() -1; i++){
+            lineDrawList[i]->resetMarking();
         }
     }
 

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -686,8 +686,9 @@ void caLineDraw::paintEvent(QPaintEvent *)
                 m_LettersBoundingRects << rectangleToDraw;
             }
 
+            bool isLastEmpty = m_Text[i] == QString(" ") && i == (m_Text.size() -1);
             bool isCurrentFieldMarked = false;
-            if(m_LetterMarkedList.size() > 0){
+            if(m_LetterMarkedList.size() > 0 && !isLastEmpty){
                 isCurrentFieldMarked = m_LetterMarkedList[i];
             }
 

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -312,7 +312,7 @@ bool caLineDraw::rotateText(float degrees)
     return false;
 }
 
-void caLineDraw::resetMarking(){
+void caLineDraw::clearSelection(){
     m_LetterMarkedList.clear();
     m_LettersBoundingRects.clear();
     m_markAllText = false;
@@ -330,7 +330,7 @@ void caLineDraw::mousePressEvent(QMouseEvent *event)
 
         m_MouseClickPosition = calculateCoordinates(event->pos());
         // Reset Marking
-        resetMarking();
+        clearSelection();
     }
 
     if(event->buttons() == Qt::LeftButton || event->buttons() == Qt::RightButton){
@@ -392,7 +392,7 @@ void caLineDraw::keyPressEvent(QKeyEvent *event){
     if(keyPressed == Qt::Key_Escape){
         QList lineDrawList = (parent()->findChildren<caLineDraw *>());
         for(int i = 0; i <= lineDrawList.size() -1; i++){
-            lineDrawList[i]->resetMarking();
+            lineDrawList[i]->clearSelection();
         }
     }
 

--- a/caQtDM_QtControls/src/calinedraw.cpp
+++ b/caQtDM_QtControls/src/calinedraw.cpp
@@ -324,12 +324,25 @@ void caLineDraw::resetMarking(){
 }
 
 void caLineDraw::handleMultipleMarkedObjects(){
+    QString copyString;
+    bool isMoreThanOneMarked = false;
+
     QList lineDrawList = (parent()->findChildren<caLineDraw *>());
     qDebug() << "NEW:";
     for(int i = 0; i <= lineDrawList.length() -1; i++){
         if(lineDrawList[i]->m_markAllText == true){
-            qDebug() << lineDrawList[i]->objectName() << lineDrawList[i]->getPV();
+            copyString +=  lineDrawList[i]->getPV() + "\t" + lineDrawList[i]->getMarkedText() + "\n";
+            if(i == 1){isMoreThanOneMarked = true;}
         }
+    }
+    qDebug().noquote() << copyString;
+    // Copy to Clipboard
+
+    QClipboard *clipboard = QApplication::clipboard();
+    if(copyString.size() > 0 && isMoreThanOneMarked){
+        clipboard->setText(copyString);
+    }else{
+        clipboard->setText(getMarkedText());
     }
 }
 
@@ -373,13 +386,11 @@ void caLineDraw::keyPressEvent(QKeyEvent *event){
     int keyPressed = event->key();
     int event_modifier = event->modifiers();
 
-    QClipboard *clipboard = QApplication::clipboard();
-
     if(event_modifier == Qt::ControlModifier){
         switch(keyPressed){
         // CTRL + C
         case Qt::Key_C:
-            clipboard->setText(getMarkedText());
+            handleMultipleMarkedObjects();
             break;
         // CTRL + A
         case Qt::Key_A:

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -195,6 +195,7 @@ protected:
     void handleMarking(QPoint position);
     int getIndexofTextRectangle(QPoint position);
     int getDirectionOfMouseMove(QPoint startPosition, QPoint endPosition);
+    void resetMarking();
     QColor invertColor(QColor color);
     CaQtDM_Lib_Interface* caDataInterface;
 

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -190,6 +190,7 @@ protected:
     void mouseMoveEvent(QMouseEvent *event);
     void keyPressEvent(QKeyEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
+    void mouseDoubleClickEvent(QMouseEvent *event);
     int calculateSumOfStartingCoordinates(QList<int> list, int calculateUntilIndex = -1);
     QPoint calculateCoordinates(QPoint point);
     QString getMarkedText();

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -168,7 +168,7 @@ public:
     void setFormatString(const QString m) { thisFormatUserString = m; }
     QString getFormatString() {return thisFormatUserString;}
     QString getMarkedText();
-    void resetMarking();
+    void clearSelection();
     bool getMarkAll() {return m_markAllText;}
     void copy();
 

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -170,7 +170,7 @@ public:
     QString getMarkedText();
     void resetMarking();
     bool getMarkAll() {return m_markAllText;}
-    QString getText() {return m_Text;}
+    void copy();
 
 signals:
     void textChanged(QString);

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -167,6 +167,10 @@ public:
 
     void setFormatString(const QString m) { thisFormatUserString = m; }
     QString getFormatString() {return thisFormatUserString;}
+    QString getMarkedText();
+    void resetMarking();
+    bool getMarkAll() {return m_markAllText;}
+    QString getText() {return m_Text;}
 
 signals:
     void textChanged(QString);
@@ -193,12 +197,9 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *event);
     int calculateSumOfStartingCoordinates(QList<int> list, int calculateUntilIndex = -1);
     QPoint calculateCoordinates(QPoint point);
-    QString getMarkedText();
     void handleMarking(QPoint position);
     int getIndexofTextRectangle(QPoint position);
     int getDirectionOfMouseMove(QPoint startPosition, QPoint endPosition);
-    void resetMarking();
-    void handleMultipleMarkedObjects();
     QColor invertColor(QColor color);
     CaQtDM_Lib_Interface* caDataInterface;
 

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -189,6 +189,7 @@ protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void keyPressEvent(QKeyEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event);
     int calculateSumOfStartingCoordinates(QList<int> list, int calculateUntilIndex = -1);
     QPoint calculateCoordinates(QPoint point);
     QString getMarkedText();

--- a/caQtDM_QtControls/src/calinedraw.h
+++ b/caQtDM_QtControls/src/calinedraw.h
@@ -196,6 +196,7 @@ protected:
     int getIndexofTextRectangle(QPoint position);
     int getDirectionOfMouseMove(QPoint startPosition, QPoint endPosition);
     void resetMarking();
+    void handleMultipleMarkedObjects();
     QColor invertColor(QColor color);
     CaQtDM_Lib_Interface* caDataInterface;
 

--- a/caQtDM_QtControls/src/calineedit.cpp
+++ b/caQtDM_QtControls/src/calineedit.cpp
@@ -355,6 +355,7 @@ bool caLineEdit::event(QEvent *e)
     // for context menu it will be enabled again when drag gets initiated (in caQtDM_Lib)
     } else if(e->type() == QEvent::MouseButtonPress) {
         QMouseEvent *ev = (QMouseEvent *) e;
+        setFocus();
 #if QT_VERSION< QT_VERSION_CHECK(4, 8, 0)
         if(ev->button() == Qt::MidButton) {
 #else

--- a/caQtDM_QtControls/src/camultilinestring.cpp
+++ b/caQtDM_QtControls/src/camultilinestring.cpp
@@ -274,14 +274,6 @@ bool caMultiLineString::event(QEvent *e)
             setEnabled(false);
         }
 
-    } else if(e->type() == QEvent::KeyPress) {
-
-        /*
-        QKeyEvent *key_event = static_cast<QKeyEvent*>(e);
-        if (key_event->matches(QKeySequence::Copy)) {
-            emit copy();
-        }
-        */
     }
     return QPlainTextEdit::event(e);
 }

--- a/caQtDM_QtControls/src/camultilinestring.cpp
+++ b/caQtDM_QtControls/src/camultilinestring.cpp
@@ -276,11 +276,12 @@ bool caMultiLineString::event(QEvent *e)
 
     } else if(e->type() == QEvent::KeyPress) {
 
+        /*
         QKeyEvent *key_event = static_cast<QKeyEvent*>(e);
         if (key_event->matches(QKeySequence::Copy)) {
             emit copy();
         }
-
+        */
     }
     return QPlainTextEdit::event(e);
 }

--- a/caQtDM_QtControls/src/camultilinestring.cpp
+++ b/caQtDM_QtControls/src/camultilinestring.cpp
@@ -419,3 +419,7 @@ void caMultiLineString::copy()
     clipboard->setText(s);
 }
 
+void caMultiLineString::clearSelection(){
+    textCursor().clearSelection();
+}
+

--- a/caQtDM_QtControls/src/camultilinestring.cpp
+++ b/caQtDM_QtControls/src/camultilinestring.cpp
@@ -420,6 +420,8 @@ void caMultiLineString::copy()
 }
 
 void caMultiLineString::clearSelection(){
-    textCursor().clearSelection();
+    QTextCursor c = textCursor();
+    c.clearSelection();
+    setTextCursor(c);
 }
 

--- a/caQtDM_QtControls/src/camultilinestring.h
+++ b/caQtDM_QtControls/src/camultilinestring.h
@@ -135,6 +135,7 @@ public:
     void updateAlarmColors();
     void setColors(QColor bg, QColor fg, QColor fr, int lineWidth);
     void copy();
+    void clearSelection();
 
 public slots:
     void animation(QRect p) {

--- a/caQtDM_QtControls/src/camultilinestring.h
+++ b/caQtDM_QtControls/src/camultilinestring.h
@@ -134,6 +134,7 @@ public:
     void setAlarmColors(short status, double value, QColor bgAtInit, QColor fgAtInit);
     void updateAlarmColors();
     void setColors(QColor bg, QColor fg, QColor fr, int lineWidth);
+    void copy();
 
 public slots:
     void animation(QRect p) {
@@ -146,7 +147,6 @@ public slots:
 
 private slots:
     void rescaleFont(const QString& newText);
-    void copy();
 
 protected:
       virtual bool event(QEvent *);

--- a/caQtDM_QtControls/src/catable.cpp
+++ b/caQtDM_QtControls/src/catable.cpp
@@ -116,8 +116,8 @@ void caTable::celldoubleclicked(int row, int col)
 void caTable::createActions() {
 
     copyAct = new QAction(this);
-    copyAct->setShortcut(tr("Ctrl+C"));
-    connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
+ //   copyAct->setShortcut(tr("Ctrl+C"));
+ //   connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
 }
 
 void caTable::setColumnSizes(QString const &newSizes)

--- a/caQtDM_QtControls/src/catable.cpp
+++ b/caQtDM_QtControls/src/catable.cpp
@@ -95,7 +95,6 @@ caTable::caTable(QWidget *parent) : QTableWidget(parent)
     }
 #endif
     createActions();
-    addAction(copyAct);
 
     connect(this, SIGNAL( cellDoubleClicked (int, int) ), this, SLOT(celldoubleclicked( int, int ) ) );
     setFocusPolicy(Qt::ClickFocus);
@@ -115,9 +114,6 @@ void caTable::celldoubleclicked(int row, int col)
 
 void caTable::createActions() {
 
-    copyAct = new QAction(this);
- //   copyAct->setShortcut(tr("Ctrl+C"));
- //   connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
 }
 
 void caTable::setColumnSizes(QString const &newSizes)

--- a/caQtDM_QtControls/src/catable.h
+++ b/caQtDM_QtControls/src/catable.h
@@ -109,6 +109,7 @@ public:
     void createActions();
 
     void setValueFont(QFont font);
+    void copy();
 
 public slots:
     void animation(QRect p) {
@@ -123,7 +124,6 @@ signals:
    void TableDoubleClickedSignal(QString pv);
 
 private slots:
-    void copy();
     void celldoubleclicked(int, int);
     void cellclicked(int, int);
 

--- a/caQtDM_QtControls/src/cawavetable.cpp
+++ b/caQtDM_QtControls/src/cawavetable.cpp
@@ -114,9 +114,6 @@ caWaveTable::caWaveTable(QWidget *parent) : QTableWidget(parent)
 
     connect(this, SIGNAL(currentCellChanged(int, int, int, int)), this,  SLOT(cellChange(int,int, int, int)));
 
-    createActions();
-    addAction(copyAct);
-
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     defaultForeColor = palette().foreground().color();
 #else

--- a/caQtDM_QtControls/src/cawavetable.cpp
+++ b/caQtDM_QtControls/src/cawavetable.cpp
@@ -663,9 +663,9 @@ void caWaveTable::copy()
 void caWaveTable::createActions() {
 
     copyAct = new QAction(this);
-    copyAct->setShortcut(tr("Ctrl+C"));
-    copyAct->setShortcutContext(Qt::WidgetShortcut);
-    connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
+  //  copyAct->setShortcut(tr("Ctrl+C"));
+  //  copyAct->setShortcutContext(Qt::WidgetShortcut);
+  //  connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
 }
 
 

--- a/caQtDM_QtControls/src/cawavetable.cpp
+++ b/caQtDM_QtControls/src/cawavetable.cpp
@@ -662,10 +662,6 @@ void caWaveTable::copy()
 
 void caWaveTable::createActions() {
 
-    copyAct = new QAction(this);
-  //  copyAct->setShortcut(tr("Ctrl+C"));
-  //  copyAct->setShortcutContext(Qt::WidgetShortcut);
-  //  connect(copyAct, SIGNAL(triggered()), this, SLOT(copy()));
 }
 
 

--- a/caQtDM_QtControls/src/cawavetable.h
+++ b/caQtDM_QtControls/src/cawavetable.h
@@ -121,6 +121,8 @@ public:
                                                   }
     Alignment getAlignment() const {return thisAlignment;}
 
+                                                  void copy();
+
 public slots:
     void animation(QRect p) {
 #include "animationcode.h"
@@ -131,7 +133,6 @@ public slots:
     }
 
 private slots:
-    void copy();
     void dataInput(int, int);
     void cellDoubleclicked(int, int);
     void cellClicked(int, int);

--- a/caQtDM_QtControls/src/enumeric.cpp
+++ b/caQtDM_QtControls/src/enumeric.cpp
@@ -400,16 +400,20 @@ void ENumeric::mouseDoubleClickEvent(QMouseEvent*)
 {
     if (text == NULL) {
         text = new QLineEdit(this);
-        connect(text, SIGNAL(returnPressed()), this, SLOT(dataInput()));
-        connect(text, SIGNAL(editingFinished() ), text, SLOT(hide()));
+    }else{
+        text->raise();
+        text->show();
     }
+    connect(text, SIGNAL(returnPressed()), this, SLOT(dataInput()));
+    connect(text, SIGNAL(editingFinished()), text, SLOT(hide()));
+
     text->setGeometry(QRect(box->cellRect(1, 0).topLeft(), box->cellRect(1, box->columnCount() - 1).bottomRight()));
     text->setFont(signLabel->font());
     text->setAlignment(Qt::AlignRight);
     text->setMaxLength(digits+2);
     text->setText("");
     text->setFocus();
-    text->show();
+
 }
 
 bool ENumeric::eventFilter(QObject *obj, QEvent *event)

--- a/caQtDM_Tests/softioc.bat
+++ b/caQtDM_Tests/softioc.bat
@@ -1,7 +1,7 @@
 @echo on
 set PATH=D:\epics\Package\base\bin\windows-x64;%PATH%
 cd D:\qt\caqtdm_project\caQtDM_Tests
-softioc.exe -D D:\epics\Package\base\bin\dbd\softioc.dbd st.cmd
+softioc.exe -D D:\epics\Package\base\dbd\softioc.dbd st.cmd
 cd ..\..
 
 pause

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -2976,6 +2976,28 @@ CAQTDM_DEFAULT_UNIT_REPLACEMENTS
 It is not recommended to disable them, as they are tested on all common systems and should be working with most clients, however disabling might help
 in some edge cases.
 
+Copying and selecting Text
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Multiple widgets support some kind of selection of their displayed values. All of them also enable copying of their values into the clipboard.
+They do not behave exactly the same, but their differences are relatively minor and mostly in how they are implemented: 
+
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| Widget                 | Ctrl+C | Ctrl+A | Behaviour on Single Click| Behaviour on Double-Click   |  Selection on Change  |
++========================+========+========+==========================+=============================+=======================+
+| caLineDraw             |  true  |  true  |  nothing                 |  marks entire text          |  retained             |
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| caLineEdit             |  true  |  true  |  nothing                 |  marks entire text          |  lost                 |
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| caMultiLineString      |  true  |  true  |  nothing                 |  marks entire text          |  not tested           |
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| caTable                |  true  |  true  |  marks current cell      |  deselects current cell     |  retained             |
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| caWaveTable            |  true  |  true  |  marks current cell      |  enables editing of cell    |  not tested           |
++------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
+| caTextEntry            |  true  |  true  |  enables editing of cell |  marks entire text          |  lost                 |
++------------------------+--------------------------------------------+-----------------------------+-----------------------+
+
 .. _env.var:
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -2982,6 +2982,7 @@ Copying and selecting Text
 Multiple widgets support some kind of selection of their displayed values. All of them also enable copying of their values into the clipboard.
 They do not behave exactly the same, but their differences are relatively minor and mostly in how they are implemented: 
 
+**Comparison**
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
 | Widget                 | Ctrl+C | Ctrl+A | Behaviour on Single Click| Behaviour on Double-Click   |  Selection on Change  |
 +========================+========+========+==========================+=============================+=======================+
@@ -2997,6 +2998,27 @@ They do not behave exactly the same, but their differences are relatively minor 
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
 | caTextEntry            |  true  |  true  |  enables editing of cell |  marks entire text          |  lost                 |
 +------------------------+--------------------------------------------+-----------------------------+-----------------------+
+
+**Shortcuts**
+Although the widgets might work differently, the shortcuts are the same across all of them. The shortcuts use, if any exists, the industry standard that most people are familiar with.
+When no industry standard is available, caQtDM uses the Combination ``Ctrl+Alt``, in combination with the first letter of the action performed (Ex. **R** for **R**eload in ``Ctrl+Alt+R``).
+
++------------------+-----------------------------------------------------+
+| ``Ctrl+C``       | Copies currently selected text to clipboard         |
++------------------+-----------------------------------------------------+
+| ``Ctrl+A``       | Selects entirety of the text inside a widget        |
++------------------+-----------------------------------------------------+
+| ``Ctrl+Alt+D``   | Removes selection from all widgets currently marked |
++------------------+-----------------------------------------------------+
+| ``Ctrl+R``       | Reload current window                               |
++------------------+-----------------------------------------------------+
+| ``Ctrl+Alt+R``   | Reload all windows                                  |
++------------------+-----------------------------------------------------+
+| ``Ctrl+O``       | Open File                                           |
++------------------+-----------------------------------------------------+
+| ``Ctrl+P``       | Print                                               |
++------------------+-----------------------------------------------------+
+
 
 .. _env.var:
 Environment Variables

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -1584,7 +1584,7 @@ curves
       when either one changes, in the case of X, Y Scalar) a new point
       is plotted until there are Count points. The points are plotted
       from i = 0 to the lesser of Count -1 and the number of updates.
-      When the Plot Mode is "PlotNPointsAndStop",ù no more points are
+      When the Plot Mode is "PlotNPointsAndStop", no more points are
       plotted. When the Plot Mode is "PlotLastNPoints", the earliest point
       is discarded and the others are moved down, and the latest is
       plotted at the end. In the cases where one of the process
@@ -2806,7 +2806,7 @@ other string, both on the command line and when calling a `related
 display <#RelatedDisplay>`__. Specific directions for each of these
 cases are given in the correspoonding sections of the manual. In
 general, there is an argument string with the form
-``name1=value1[,name2=value2]...``.  All occurrences of "(name1)"ù in the
+``name1=value1[,name2=value2]...``.  All occurrences of "(name1)" in the
 ``.ui`` file are replaced with "value1", then all occurences of $(name2)
 are replaced by value2, *etc*. The substitition is recursive; that is,
 if value1 contains an occurrence of $(name2), then when name2=value2
@@ -2964,7 +2964,7 @@ You have to first write the source characters you want to replace, then an equal
 character replacements, seperate them by semicolon (;). Parts that dont contain an equal sign but are seperated from other parts with semicolon are ignored. All put together this would be the structure:
 CAQTDM_CUSTOM_UNIT_REPLACEMENTS={sourceCharacters}={replacementCharacters};{anotherReplacement}
 An example (that doesnt make much sense but displays many possibilities) would be:
-CAQTDM_CUSTOM_UNIT_REPLACEMENTS=charsToReplace=charsToUse;0x48,0x68=bye;charsWithHex,0x4f=something;∞=o
+CAQTDM_CUSTOM_UNIT_REPLACEMENTS=charsToReplace=charsToUse;0x48,0x68=bye;charsWithHex,0x4f=something;
 It can be seen that all combinations of strings, hex- and deciaml character codes are possible to form a source or replacement string.
 All replacements will be done sequentially, with the leftmost replacements being done first. Therefore, it can also be possible, that later replacements replace characters in a string
 that has already been replaced before by another replacements.

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -2990,11 +2990,11 @@ They do not behave exactly the same, but their differences are relatively minor 
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
 | caLineEdit             |  true  |  true  |  nothing                 |  marks entire text          |  lost                 |
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
-| caMultiLineString      |  true  |  true  |  nothing                 |  marks entire text          |  not tested           |
+| caMultiLineString      |  true  |  true  |  nothing                 |  marks entire text          |  lost                 |
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
 | caTable                |  true  |  true  |  marks current cell      |  deselects current cell     |  retained             |
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
-| caWaveTable            |  true  |  true  |  marks current cell      |  enables editing of cell    |  not tested           |
+| caWaveTable            |  true  |  true  |  marks current cell      |  enables editing of cell    |  lost                 |
 +------------------------+--------+--------+--------------------------+-----------------------------+-----------------------+
 | caTextEntry            |  true  |  true  |  enables editing of cell |  marks entire text          |  lost                 |
 +------------------------+--------------------------------------------+-----------------------------+-----------------------+


### PR DESCRIPTION
Improved Functionality of the Marking within caLineDraw; 
- Added Double-Click to Select all within Widget,
- Handling Copying across caLineDraw, caTextEdit usw. to be relatively close to each other in how they work