### PR TITLE
Fixed wrong text color in messagewindow when changing theme at runtime

### DIFF
--- a/caQtDM_Lib/src/MessageWindow.cpp
+++ b/caQtDM_Lib/src/MessageWindow.cpp
@@ -35,6 +35,7 @@
 #include <QFile>
 #include <QDebug>
 #include <QTextStream>
+#include <QScrollBar>
 #ifndef MOBILE_ANDROID
 #include <sys/timeb.h>
 #else
@@ -159,6 +160,29 @@ QString MessageWindow::getMessageBoxContents() {
 QString MessageWindow::getLogFilePath()
 {
     return m_logFilePath;
+}
+
+void MessageWindow::themeChanged() {
+    QApplication* guiApp = qobject_cast<QApplication*>(qApp);
+    QPalette palette = guiApp->palette();
+    QString oldColorNormalHex = m_normalTextColorHex;
+    QString oldColorDebugHex = m_debugTextColorHex;
+    m_normalTextColorHex = palette.color(QPalette::Active, QPalette::Text).name();
+    m_debugTextColorHex = palette.color(QPalette::Active, QPalette::Link).name();
+
+    if (oldColorNormalHex != m_normalTextColorHex || oldColorDebugHex != m_debugTextColorHex) {
+        redrawText(oldColorNormalHex, oldColorDebugHex);
+    }
+}
+
+void MessageWindow::redrawText(const QString& oldNormalTextColorHex, const QString& oldDebugTextColorHex) {
+    QString text = msgTextEdit.toHtml();
+    text = text.replace(oldNormalTextColorHex, m_normalTextColorHex).replace(oldDebugTextColorHex, m_debugTextColorHex);
+    msgTextEdit.setHtml(text);
+    QScrollBar *vScrollBar = msgTextEdit.verticalScrollBar();
+    if (vScrollBar) {
+        vScrollBar->setValue(vScrollBar->maximum());
+    }
 }
 
 void MessageWindow::postMsgEvent(QtMsgType type, char* msg)

--- a/caQtDM_Lib/src/MessageWindow.h
+++ b/caQtDM_Lib/src/MessageWindow.h
@@ -77,6 +77,7 @@ private:
 
     QString m_normalTextColorHex;
     QString m_debugTextColorHex;
+    void redrawText(const QString& oldNormalTextColorHex, const QString& oldDebugTextColorHex);
 protected:
 
     virtual void customEvent(QEvent* event);
@@ -90,6 +91,9 @@ public:
     void clearText();
     QString getMessageBoxContents();
     QString getLogFilePath();
+
+public slots:
+    void themeChanged();
 };
 
 class CAQTDM_LIBSHARED_EXPORT MessageEvent: public QEvent

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -286,6 +286,8 @@ FileOpenWindow::FileOpenWindow(QMainWindow* parent,  QString filename, QString m
     setGeometry(0,0, 300, 150);
     this->statusBar()->show();
 
+    connect(this, &FileOpenWindow::themeChanged, messageWindow, &MessageWindow::themeChanged);
+
     // connect action buttons
     connect( this->ui.fileAction, SIGNAL( triggered() ), this, SLOT(Callback_OpenButton()) );
     connect( this->ui.aboutAction, SIGNAL( triggered() ), this, SLOT(Callback_ActionAbout()) );
@@ -1984,6 +1986,14 @@ bool FileOpenWindow::event(QEvent *e)
         qDebug()<<"QEvent::Show!";
         // Qt 6.5.2 ShowMinimized=crash in QWidget::event better solution = setVisible(false)
         if (!debugWindow) this->setVisible(false);
+    }
+    return QWidget::event(e);
+}
+#else
+bool FileOpenWindow::event(QEvent *e)
+{
+    if (e->type() == QEvent::ThemeChange) {
+        emit themeChanged();
     }
     return QWidget::event(e);
 }

--- a/caQtDM_Viewer/src/fileopenwindow.cpp
+++ b/caQtDM_Viewer/src/fileopenwindow.cpp
@@ -1994,6 +1994,8 @@ bool FileOpenWindow::event(QEvent *e)
 {
     if (e->type() == QEvent::ThemeChange) {
         emit themeChanged();
+        // we don't retun true here, because we want the base implementation and
+        // all child items to also receive the ThemeChange event, so they can correctly change to the new theme.
     }
     return QWidget::event(e);
 }

--- a/caQtDM_Viewer/src/fileopenwindow.h
+++ b/caQtDM_Viewer/src/fileopenwindow.h
@@ -255,15 +255,15 @@ public slots:
      void Callback_ReloadAllWindows();
 
 protected:
-#ifdef MOBILE
      virtual bool event(QEvent *);
-#endif
+
      virtual void timerEvent(QTimerEvent *e);
      Qt::GestureType fingerSwipeGestureType;
      bool eventFilter(QObject *obj, QEvent *event);
 
 signals:
    void messageAvailable(QString message);
+   void themeChanged();
 
 private:
    void setDirectUpdateTypeOnRestart(const QDateTime);


### PR DESCRIPTION
These changes allow the user to change the theme at the runtime of caQtDM without having to look at text in the wrong color