### PR TITLE
Modified QtControls to compile using Qwt 6.3.0

### DIFF
--- a/caQtDM_BuildAll
+++ b/caQtDM_BuildAll
@@ -32,7 +32,7 @@ echo
 read -p "Press [Enter] key to start build "
 
 echo ============ make all =================
-qmake all.pro
+qmake-qt5 all.pro
 #scan-build --use-analyzer Xcode make -j8
 make -j8
 

--- a/caQtDM_QtControls/caQtDM_QtControls.pro
+++ b/caQtDM_QtControls/caQtDM_QtControls.pro
@@ -207,7 +207,7 @@ contains(QWT_VER_MIN, 0) {
    HEADERS	+= src/qwt_thermo_marker.h
    SOURCES	+= src/qwt_thermo_marker.cpp
 }
-contains(QWT_VER_MIN, 1)|contains(QWT_VER_MIN, 2) {
+contains(QWT_VER_MIN, 1)|contains(QWT_VER_MIN, 2)|contains(QWT_VER_MIN, 3) {
    HEADERS	+= src/qwt_thermo_marker_61.h
    SOURCES	+= src/qwt_thermo_marker_61.cpp
 }


### PR DESCRIPTION
Make complained with undefined reference to class QwtThermoMarker, with Qwt 6.3.0 this was excluded from the build (from caQtDM_QtControls.pro #210) v4.5.0 compiles with Qwt 6.3.0