### PR TITLE
Fix engr_notation to use multiples of 3 in exponent and keep line lengths constant

### DIFF
--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -695,10 +695,10 @@ CaQtDM_Lib::CaQtDM_Lib(QWidget *parent, QString filename, QString macro, MutexKn
     printf("caQtDM -- user_defined_stylesheet: %s \n",qasc(qApp->property("user_defined_stylesheet").toString()));
     fflush(stdout);
     if (qApp->property("user_defined_stylesheet").isValid() && (!qApp->property("user_defined_stylesheet").toString().isEmpty())){
+        QString printdata=qApp->styleSheet();
         QString stylereload = (QString)  qgetenv("CAQTDM_STYLESHEET_RELOAD");
-        //if (stylereload.isEmpty()) qApp->setStyleSheet(qApp->styleSheet());
-
         if (stylereload.contains("file",Qt::CaseInsensitive)){
+            printf("caQtDM -- search for: %s\n",qasc(qApp->property("user_defined_stylesheet").toString()));
             searchFile *searchDefaultStyleSheet = new searchFile(qApp->property("user_defined_stylesheet").toString());
             QString fileNameFound = searchDefaultStyleSheet->findFile();
             printf("caQtDM -- custom stylesheet found: %s\n",qasc(fileNameFound));
@@ -706,25 +706,25 @@ CaQtDM_Lib::CaQtDM_Lib(QWidget *parent, QString filename, QString macro, MutexKn
                 QFile file(fileNameFound);
                 file.open(QFile::ReadOnly);
                 QString StyleSheet = QLatin1String(file.readAll());
-                printf("caQtDM -- custom stylesheet file <%s> replaced the default stylesheet\n", qasc(fileNameFound));
+                printdata=StyleSheet;
+                printf("caQtDM -- custom stylesheet file <%s> reloaded stylesheet\n", qasc(fileNameFound));
                 fflush(stdout);
-                if (!stylereload.contains("later",Qt::CaseInsensitive)) qApp->setStyleSheet(StyleSheet);
+                if (stylereload.contains("later",Qt::CaseInsensitive)){
+                    QTimer::singleShot(3000, this, [this,StyleSheet] () {
+                            this->setStyleSheet(StyleSheet);
+                        });
+                }else setStyleSheet(StyleSheet);
                 file.close();
             }
             delete searchDefaultStyleSheet;
         }
         if (stylereload.contains("apply",Qt::CaseInsensitive)){
-            qApp->setStyleSheet(qApp->styleSheet());
+            setStyleSheet(qApp->styleSheet());
         }
+
         if (stylereload.contains("print",Qt::CaseInsensitive)){
-            QString data=qApp->styleSheet();
-            printf("caQtDM -- custom stylesheet file data:\n%s \n", qasc(data));
+            printf("caQtDM -- custom stylesheet file data:\n%s \n", qasc(printdata));
             fflush(stdout);
-        }
-        if (stylereload.contains("later",Qt::CaseInsensitive)){
-            QTimer::singleShot(300, this, [] () {
-                    qApp->setStyleSheet(qApp->styleSheet());
-                });
         }
     }
 

--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -7399,7 +7399,7 @@ void CaQtDM_Lib::Callback_ScriptButton()
 {
 #ifndef MOBILE
     QString command = "";
-    bool displayWindow;
+    bool displayWindow,CloseOnExit0;
     caScriptButton *w = qobject_cast<caScriptButton *>(sender());
     command.append(w->getScriptCommand());
 
@@ -7414,9 +7414,10 @@ void CaQtDM_Lib::Callback_ScriptButton()
     }
 #endif
     displayWindow = w->getDisplayShowExecution();
+    CloseOnExit0 = w->getCloseExit0();
 
     if(w->getAccessW()) {
-        processWindow *t = new processWindow(this, displayWindow, w);
+        processWindow *t = new processWindow(this, displayWindow,CloseOnExit0, w);
         connect(t, SIGNAL(processClose()), this, SLOT(processTerminated()));
 #ifdef _MSC_VER
         t->setArguments(w->getScriptParam());

--- a/caQtDM_Lib/src/processWindow.cpp
+++ b/caQtDM_Lib/src/processWindow.cpp
@@ -25,12 +25,13 @@
 
 #include "processWindow.h"
 
-processWindow::processWindow(QWidget *parent, bool display, QWidget *caller): QMainWindow(parent)
+processWindow::processWindow(QWidget *parent, bool display, bool CloseExit0, QWidget *caller): QMainWindow(parent)
 {
     outputWindow = (QTextEdit *) Q_NULLPTR;
     debugWindow = (QTextEdit *) Q_NULLPTR;
     splitter = (QSplitter *) Q_NULLPTR;
     displayWindow = display;
+    m_CloseExit0 = CloseExit0;
     thisCaller = caller;
     thisPID =(Q_PID) Q_NULLPTR;
 
@@ -180,7 +181,7 @@ void processWindow::processFinished()
     QTextCursor cursor = outputWindow->textCursor(); // retrieve  cursor
     cursor.movePosition(QTextCursor::End);           // move to the end of text
     outputWindow->setTextCursor(cursor);
-    if (termProcess->exitCode()==0){
+    if ( m_CloseExit0 && (termProcess->exitCode()==0)){
         tryTerminate();
     }
 

--- a/caQtDM_Lib/src/processWindow.h
+++ b/caQtDM_Lib/src/processWindow.h
@@ -48,7 +48,7 @@ class CAQTDM_LIBSHARED_EXPORT processWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    processWindow(QWidget * = 0, bool display=true, QWidget * = 0);
+    processWindow(QWidget * = 0, bool display=true, bool CloseExit0=false, QWidget * = Q_NULLPTR);
     ~processWindow();
 
     bool isRunning();
@@ -82,6 +82,7 @@ private:
     QProcess *termProcess;
     QSplitter* splitter;
     bool displayWindow;
+    bool m_CloseExit0;
     QWidget *thisCaller;
     Q_PID thisPID;
     QString arguments;

--- a/caQtDM_QtControls/src/calineedit.cpp
+++ b/caQtDM_QtControls/src/calineedit.cpp
@@ -384,6 +384,7 @@ void caLineEdit::setFormat(int prec)
     if(thisPrecMode == User) {
         precision = getPrecision();
     }
+    usePrecision = precision;
     switch (thisFormatType) {
     case string:
     case decimal:
@@ -429,6 +430,102 @@ void caLineEdit::setFormat(int prec)
     }
 }
 
+/**
+ * Converts a double to engineering notation and writes to a char array
+ * 
+ * @param buffer    Destination char array
+ * @param bufferLen Size of the buffer (including space for null terminator)
+ * @param value     The double value to convert
+ * @param precision Number of digits after the decimal point
+ * @return          Number of characters written (excluding null), or -1 on error
+ */
+int toEngineeringNotation(char* buffer, size_t bufferLen, double value, int precision = 3) {
+    // Validate inputs
+    if (buffer == nullptr || bufferLen == 0) {
+        return -1;
+    }
+    
+    // Clamp precision to reasonable bounds
+    if (precision < 0) precision = 0;
+    if (precision > 15) precision = 15;
+    
+    // Handle special cases
+    if (std::isnan(value)) {
+        if (bufferLen < 4) { buffer[0] = '\0'; return -1; }
+        std::strcpy(buffer, "nan");
+        return 3;
+    }
+    
+    if (std::isinf(value)) {
+        const char* result = (value > 0) ? "inf" : "-inf";
+        size_t len = std::strlen(result);
+        if (bufferLen <= len) { buffer[0] = '\0'; return -1; }
+        std::strcpy(buffer, result);
+        return static_cast<int>(len);
+    }
+    
+    if (value == 0.0) {
+        int written = std::snprintf(buffer, bufferLen, " %.*fe+00", precision, 0.0);
+        if (written < 0 || static_cast<size_t>(written) >= bufferLen) {
+            buffer[0] = '\0';
+            return -1;
+        }
+        return written;
+    }
+    
+    // Handle negative numbers
+    bool negative = value < 0;
+    double absValue = std::fabs(value);
+    
+    // Calculate the exponent (power of 10)
+    int exponent = static_cast<int>(std::floor(std::log10(absValue)));
+    
+    // Adjust exponent to be a multiple of 3
+    int engExponent;
+    if (exponent >= 0) {
+        engExponent = exponent - (exponent % 3);
+    } else {
+        // Handle negative exponents correctly
+        int mod = exponent % 3;
+        engExponent = (mod == 0) ? exponent : exponent - (3 + mod);
+    }
+    
+    // Calculate the mantissa
+    double mantissa = absValue / std::pow(10.0, engExponent);
+    
+    // Handle floating point precision issues
+    // Mantissa should be in range [1, 1000)
+    if (mantissa >= 999.9999999999) {
+        mantissa /= 1000.0;
+        engExponent += 3;
+    } else if (mantissa < 1.0) {
+        mantissa *= 1000.0;
+        engExponent -= 3;
+    }
+    int written;
+
+    // Apply sign
+    // Format the output
+    // Format: [-]d.ddde±ee (sign + digits + decimal + precision + 'e' + sign + 2-3 digits)
+    if (negative) {
+      written = std::snprintf(buffer, bufferLen, "-%3.*fe%+03d", 
+                              precision - (exponent - engExponent), mantissa, engExponent);
+    }else{
+      written = std::snprintf(buffer, bufferLen, " %3.*fe%+03d", 
+                              precision - (exponent - engExponent), mantissa, engExponent);
+    }
+    
+    
+    if (written < 0 || static_cast<size_t>(written) >= bufferLen) {
+        buffer[0] = '\0';
+        return -1;
+    }
+    
+    return written;
+}
+
+
+
 void caLineEdit::setValue(double value, const QString& units)
 {
     char asc[MAX_STRING_LENGTH];
@@ -440,6 +537,11 @@ void caLineEdit::setValue(double value, const QString& units)
       } else {
         snprintf(asc, MAX_STRING_LENGTH, thisFormat, value);
       }
+    } else if(thisFormatType == engr_notation and thisDatatype == caDOUBLE)  {
+      // proper handling of engineering notation!
+      int precision = usePrecision;
+      if(precision > 17) precision = 17;
+      toEngineeringNotation(asc, MAX_STRING_LENGTH, value, precision);
     } else if (thisFormatType == user_defined_format) {
         QString pattern = QString("%[+\\- 0#]*[0-9]*([.][0-9]+)?[aefgAEFG]");
         bool isDouble=false;

--- a/caQtDM_QtControls/src/calineedit.h
+++ b/caQtDM_QtControls/src/calineedit.h
@@ -184,6 +184,7 @@ private:
     colMode oldColorMode;
 
     int thisPrecision;
+    int usePrecision;
     SourceMode thisPrecMode;
     SourceMode thisLimitsMode;
 

--- a/caQtDM_QtControls/src/cascriptbutton.h
+++ b/caQtDM_QtControls/src/cascriptbutton.h
@@ -82,6 +82,7 @@ public:
     void setScriptParam(QString const &m) {thisScriptParam = m;}
 
     bool getDisplayShowExecution() const { return thisShowExecution;}
+    bool getCloseExit0() const { return thisDefaultDisplay==CloseOnExit0;}
 
     void setFontScaleModeL(EPushButton::ScaleMode m);
     EPushButton::ScaleMode fontScaleMode();

--- a/caQtDM_Viewer/package/rhel/caqtdm.spec
+++ b/caQtDM_Viewer/package/rhel/caqtdm.spec
@@ -29,7 +29,7 @@
 Name:    caqtdm 
 Summary: Qt Widgets for Technical Applications
 Version: 4.6.0
-Release: 1.1%{?dist}
+Release: 1.2%{?dist}
 #############################################################################
 License: GPLv3
 URL:     https://github.com/caqtdm/caqtdm

--- a/caQtDM_Viewer/package/rhel/caqtdm.spec
+++ b/caQtDM_Viewer/package/rhel/caqtdm.spec
@@ -29,7 +29,7 @@
 Name:    caqtdm 
 Summary: Qt Widgets for Technical Applications
 Version: 4.6.0
-Release: 1.0%{?dist}
+Release: 1.1%{?dist}
 #############################################################################
 License: GPLv3
 URL:     https://github.com/caqtdm/caqtdm


### PR DESCRIPTION
Here is a bit of code that truly formats into engr notation. It requires a usePrecision field to be added to the lineedit class because the setFormat is called independently from the setValue and since the precision can't be stored in the format string for this new method it has to be stored somewhere. 

This replicates similar formatting from MEDM: https://github.com/epics-extensions/medm/blob/adade992fd577309906a93bd4b48330c270086c4/medm/updateMonitors.c#L47

Though the code is not a copy.

Here is a view with engr formatting. It adjusts the precision so that the length stays constant and the "dot" moves.

<img width="645" height="121" alt="image" src="https://github.com/user-attachments/assets/3ae331e1-43e4-4ccc-92ef-e1a5b1a97179" />
