### PR TITLE
Updated archlinux build pipeline

### DIFF
--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -52,6 +52,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Create non-root builder user
       run: |

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -18,9 +18,6 @@ jobs:
       actions: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
     - name: Initialize Arch keyring and update system
       run: |
         set -euo pipefail

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -56,9 +56,10 @@ jobs:
     - name: Build package from PKGBUILD
       run: |
         set -euo pipefail
-        sudo -u builder bash -lc 'cd "$GITHUB_WORKSPACE/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
+        WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
+        sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
         pacman -U --noconfirm caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
-        sudo -u builder bash -lc 'cd "$GITHUB_WORKSPACE/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
+        sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -38,11 +38,17 @@ jobs:
           readline \
           python \
           qt6-base \
+          qt6-declarative \
+          qt6-positioning \
+          qt6-serialbus \
           qt6-tools \
           qwt \
           zeromq \
           git \
-          qt6-5compat
+          qt6-5compat \
+          cmake \
+          ninja \
+          openssl
 
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -71,7 +77,14 @@ jobs:
         path: caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
         key: epics-base-pkg-${{ runner.os }}-${{ hashFiles('caQtDM_Viewer/package/archlinux/epics-base/PKGBUILD', 'caQtDM_Viewer/package/archlinux/epics-base/*.patch') }}
 
-    - name: Build package from PKGBUILD
+    - name: Cache qt6-opcua package
+      id: cache-qt6-opcua
+      uses: actions/cache@v5
+      with:
+        path: caQtDM_Viewer/package/archlinux/qt6-opcua/*.pkg.tar.*
+        key: qt6-opcua-pkg-${{ runner.os }}-${{ hashFiles('caQtDM_Viewer/package/archlinux/qt6-opcua/PKGBUILD') }}
+
+    - name: Build and install dependency packages
       run: |
         set -euo pipefail
         WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
@@ -83,7 +96,20 @@ jobs:
           sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
         fi
 
+        if ls "$WORKSPACE_DIR"/caQtDM_Viewer/package/archlinux/qt6-opcua/*.pkg.tar.* >/dev/null 2>&1; then
+          echo "Using cached qt6-opcua package"
+        else
+          echo "No cached qt6-opcua package found, building..."
+          sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/qt6-opcua" && makepkg --noconfirm --cleanbuild'
+        fi
+
         pacman -U --noconfirm caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
+        pacman -U --noconfirm caQtDM_Viewer/package/archlinux/qt6-opcua/*.pkg.tar.*
+
+    - name: Build caQtDM package
+      run: |
+        set -euo pipefail
+        WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
         sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
 
     - name: Upload package artifact
@@ -97,3 +123,9 @@ jobs:
       with:
         name: epics-base-archlinux-package
         path: caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
+
+    - name: Upload qt6-opcua package artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: qt6-opcua-archlinux-package
+        path: caQtDM_Viewer/package/archlinux/qt6-opcua/*.pkg.tar.*

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -47,6 +47,9 @@ jobs:
           git \
           qt6-5compat
 
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
     - name: Create non-root builder user
       run: |
         set -euo pipefail

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -1,332 +1,73 @@
-name: caQtDM CI Build
+name: caQtDM Arch Linux Package Build
 
 on:
-  push:
-  pull_request:
-  # Allow manual triggering of the workflow
   workflow_dispatch:
+  pull_request:
+  push:
 
 jobs:
   build:
-    name: Build caQtDM
+    name: Build Arch package
     runs-on: ubuntu-latest
     container:
       image: archlinux/archlinux:latest
       options: --privileged
+
     permissions:
       contents: read
       actions: write
 
     steps:
-    - name: Set up build environment, create non-root user and install official repository dependencies
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Initialize Arch keyring and update system
       run: |
+        set -euo pipefail
         pacman-key --init
         pacman-key --populate archlinux
         pacman -Syu --noconfirm
 
-        # Install base-devel which covers make, gcc, patch, git
-        pacman -S --noconfirm base-devel sudo
-
-        # Install other specified dependencies and makedepends
-        # glibc, gcc-libs, bash are already preinstalled
-        # python is python3.
-        pacman -S --noconfirm \
-          qt6-base \
-          qt6-declarative \
-          qt6-tools \
-          openssl \
-          zeromq \
-          python \
-          qt6-5compat \
-          qt6-websockets \
-          git \
-          ncurses \
+    - name: Install build dependencies
+      run: |
+        set -euo pipefail
+        pacman -S --needed --noconfirm \
+          base-devel \
+          sudo \
+          gcc-libs \
+          glibc \
           perl \
+          ncurses \
           readline \
-          qt6-svg \
-          cmake \
-          ninja
+          python \
+          qt6-base \
+          qt6-tools \
+          qwt \
+          zeromq \
+          git \
+          qt6-5compat
 
-        echo "Creating non-root user 'builder' for makepkg..."
-        useradd -m -G wheel builder
-        echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-      shell: bash
-
-    - name: Checkout repository
-      uses: actions/checkout@v5
-
-    - name: Optimize makepkg.conf for parallel building
+    - name: Create non-root builder user
       run: |
-        NUM_CORES=$(nproc)
-        echo "Detected ${NUM_CORES} CPU cores. Optimizing /etc/makepkg.conf..."
+        set -euo pipefail
+        useradd -m -s /bin/bash builder
+        chown -R builder:builder "$GITHUB_WORKSPACE"
 
-        # Remove any existing MAKEFLAGS line
-        grep -v "^MAKEFLAGS=" /etc/makepkg.conf > /tmp/makepkg.conf.tmp
-
-        # Append the new MAKEFLAGS line with the actual number of cores
-        echo "MAKEFLAGS=\"-j${NUM_CORES}\"" >> /tmp/makepkg.conf.tmp
-
-        # Replace the original file
-        mv /tmp/makepkg.conf.tmp /etc/makepkg.conf
-
-        echo "Current MAKEFLAGS in /etc/makepkg.conf:"
-        grep "MAKEFLAGS" /etc/makepkg.conf
-      shell: bash
-
-    - name: Configure builder user environment and import GPG key
+    - name: Build package from PKGBUILD
       run: |
-        export AUR_DIR="$(pwd)/aur_packages"
-        mkdir -p "$AUR_DIR"
-        chown -R builder:builder "$AUR_DIR"
+        set -euo pipefail
+        sudo -u builder bash -lc 'cd "$GITHUB_WORKSPACE/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
+        pacman -U --noconfirm caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
+        sudo -u builder bash -lc 'cd "$GITHUB_WORKSPACE/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
 
-        echo "Importing PGP key for epics-base as builder user..."
-        sudo -u builder bash -c "
-          export HOME=/home/builder
-          gpg --recv-keys 6C741EFAAE4AF616
-        "
-      shell: bash
-
-    - name: Install AUR dependencies (qwt-qt6, epics-base)
-      run: |
-        export AUR_DIR="$(pwd)/aur_packages"
-        mkdir -p "$AUR_DIR"
-
-        sudo -u builder bash -c "
-          export AUR_DIR='$AUR_DIR'
-          
-          # Function to clone an AUR package with a fallback to the GitHub mirror
-          git_clone_aur_with_fallback() {
-            local package_name=\"\$1\"
-            local primary_aur_url=\"https://aur.archlinux.org/\${package_name}.git\"
-            local github_mirror_url=\"https://github.com/archlinux/aur.git\"
-            local target_dir=\"\$(pwd)/\${package_name}\"
-
-            echo \"Attempting to clone '\${package_name}' from primary AUR...\"
-            if git clone --depth 1 \"\$primary_aur_url\" \"\$target_dir\" &> /dev/null; then
-              echo \"Successfully cloned '\${package_name}' from primary AUR.\"
-              return 0
-            else
-              echo \"Failed to clone '\${package_name}' from primary AUR. Trying GitHub mirror...\"
-              # Clean up incomplete directory from failed primary attempt
-              rm -rf \"\$target_dir\"
-
-              # Clone from GitHub mirror, using the package name as a branch
-              if git clone --depth 1 --branch \"\$package_name\" --single-branch \"\$github_mirror_url\" \"\$target_dir\" &> /dev/null; then
-                echo \"Successfully cloned '\${package_name}' from GitHub mirror.\"
-                return 0
-              else
-                echo \"Failed to clone '\${package_name}' from both primary AUR and GitHub mirror.\"
-                return 1
-              fi
-            fi
-          }
-
-          # Function to install a single AUR package
-          install_aur_package() {
-            local package_name=\"\$1\"
-            echo \"Installing '\${package_name}' from AUR as builder user...\"
-
-            # Ensure we are in the correct base directory ($AUR_DIR) before attempting to clone
-            cd \"\$AUR_DIR\" || { echo \"Error: Could not change to \$AUR_DIR.\"; exit 1; }
-
-            if git_clone_aur_with_fallback \"\$package_name\"; then
-              cd \"\$package_name\" || { echo \"Error: Could not change to \${package_name} directory.\"; exit 1; }
-              makepkg -si --noconfirm
-              # After building, return to the base AUR_DIR for the next package
-              cd \"\$AUR_DIR\" || { echo \"Error: Could not change back to \$AUR_DIR.\"; exit 1; }
-            else
-              echo \"Skipping '\${package_name}' due to cloning failure.\"
-            fi
-          }
-
-          cd \"\$AUR_DIR\" || { echo \"Error: Initial change to \$AUR_DIR failed.\"; exit 1; }
-          
-          if git_clone_aur_with_fallback qwt-qt6; then
-            cd qwt-qt6 || { echo \"Error: Could not change to qwt-qt6 directory.\"; exit 1; }
-            patch -p1 < ../../.github/workflows/qwt-makepkg.patch
-
-            makepkg -si --noconfirm
-            cd \"\$AUR_DIR\" || { echo \"Error: Could not change back to \$AUR_DIR.\"; exit 1; }
-          else
-            echo \"Skipping 'qwt-qt6' due to cloning failure.\"
-          fi
-
-          install_aur_package epics-base
-        "
-      shell: bash
-
-    - name: Build and install Qt OPC UA
-      run: |
-        set -e
-
-        SRC=/opt/qtopcua-src
-        rm -rf "$SRC"
-        git clone https://code.qt.io/qt/qtopcua.git "$SRC"
-        cd "$SRC"
-        QT_VERSION=$(qmake6 -query QT_VERSION)
-        git checkout "v$QT_VERSION"
-
-        mkdir build
-        cd build
-
-        cmake .. -G "Ninja" -DCMAKE_BUILD_TYPE=Release
-        cat config.summary
-        ninja
-        ninja install
-
-    - name: Set up caQtDM specific environment variables
-      run: |
-        # Define all variables as local shell variables first
-        local_srcdir="$(pwd)"
-        local_pythonversion="$(python --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1-2)"
-        local_carch="$(uname -m)"
-
-        local_qwtnam="qwt-qt6"
-        local_qwtinc="/usr/include/qwt-qt6"
-        local_epicsbase="/usr/lib/epics"
-        local_zmq="/usr"
-        local_qtdmrpath="/opt/caqtdm/lib/qt6"
-        local_qthome="/usr"
-        local_qwthome="/usr"
-        local_qwtversion="6.1"
-
-        # Derive complex paths using local shell variables
-        local_zmqinc="${local_zmq}/include"
-        local_zmqlib="${local_zmq}/lib"
-        local_epics_host_arch="linux-${local_carch}"
-        local_qwtnamelib="${local_qwthome}/lib" # This was QWTLIB
-
-        local_epicsinclude="${local_epicsbase}/include"
-        local_epicslib="${local_epicsbase}/lib/${local_epics_host_arch}"
-        local_epicsextensions="${local_epicsbase}/extensions"
-
-        local_qtcontrols_libs="${local_srcdir}/binaries"
-        local_caqtdm_collect="${local_srcdir}/binaries"
-        local_qtdm_rpath="/opt/caqtdm/lib/qt6"
-
-        local_qtbase="${local_qtcontrols_libs}" # QTBASE depends on QTCONTROLS_LIBS
-
-        local_caqtdm_ca_archivelibs="${local_srcdir}/binaries/"
-        local_caqtdm_logging_archivelibs="${local_srcdir}/binaries"
-
-        local_qtdm_libinstall="${local_epicsextensions}/lib/${local_epics_host_arch}"
-        local_qtdm_bininstall="${local_epicsextensions}/bin/${local_epics_host_arch}"
-
-        local_pythoninclude="/usr/include/python${local_pythonversion}"
-        local_pythonlib="/usr/lib/"
-
-        # Echo all final values to $GITHUB_ENV to make them persistent in the next steps
-        echo "srcdir=${local_srcdir}" >> $GITHUB_ENV
-        echo "QWTLIBNAME=${local_qwtnam}" >> $GITHUB_ENV
-        echo "QWTINCLUDE=${local_qwtinc}" >> $GITHUB_ENV
-        echo "EPICS_BASE=${local_epicsbase}" >> $GITHUB_ENV
-        echo "PYTHONVERSION=${local_pythonversion}" >> $GITHUB_ENV
-        echo "ZMQ=${local_zmq}" >> $GITHUB_ENV
-        echo "ZMQINC=${local_zmqinc}" >> $GITHUB_ENV
-        echo "ZMQLIB=${local_zmqlib}" >> $GITHUB_ENV
-        echo "QTDM_RPATH=${local_qtdmrpath}" >> $GITHUB_ENV
-        echo "CARCH=${local_carch}" >> $GITHUB_ENV
-        echo "EPICS_HOST_ARCH=${local_epics_host_arch}" >> $GITHUB_ENV
-        echo "QTHOME=${local_qthome}" >> $GITHUB_ENV
-        echo "QWTHOME=${local_qwthome}" >> $GITHUB_ENV
-        echo "QWTLIB=${local_qwtnamelib}" >> $GITHUB_ENV
-        echo "QWTVERSION=${local_qwtversion}" >> $GITHUB_ENV
-        echo "EPICSINCLUDE=${local_epicsinclude}" >> $GITHUB_ENV
-        echo "EPICSLIB=${local_epicslib}" >> $GITHUB_ENV
-        echo "EPICSEXTENSIONS=${local_epicsextensions}" >> $GITHUB_ENV
-        echo "QTCONTROLS_LIBS=${local_qtcontrols_libs}" >> $GITHUB_ENV
-        echo "CAQTDM_COLLECT=${local_caqtdm_collect}" >> $GITHUB_ENV
-        echo "QTBASE=${local_qtbase}" >> $GITHUB_ENV
-        echo "CAQTDM_CA_ARCHIVELIBS=${local_caqtdm_ca_archivelibs}" >> $GITHUB_ENV
-        echo "CAQTDM_LOGGING_ARCHIVELIBS=${local_caqtdm_logging_archivelibs}" >> $GITHUB_ENV
-        echo "QTDM_LIBINSTALL=${local_qtdm_libinstall}" >> $GITHUB_ENV
-        echo "QTDM_BININSTALL=${local_qtdm_bininstall}" >> $GITHUB_ENV
-        echo "PYTHONINCLUDE=${local_pythoninclude}" >> $GITHUB_ENV
-        echo "PYTHONLIB=${local_pythonlib}" >> $GITHUB_ENV
-                     
-      shell: bash
-
-    - name: Debug environment variables
-      run: |
-        echo "QWTLIBNAME=${QWTLIBNAME}"
-        echo "QWTINCLUDE=${QWTINCLUDE}"
-        echo "EPICS_BASE=${EPICS_BASE}"
-        echo "PYTHONVERSION=${PYTHONVERSION}"
-        echo "ZMQ=${ZMQ}"
-        echo "ZMQINC=${ZMQINC}"
-        echo "ZMQLIB=${ZMQLIB}"
-        echo "QTDM_RPATH=${QTDM_RPATH}"
-        echo "CARCH=${CARCH}"
-        echo "EPICS_HOST_ARCH=${EPICS_HOST_ARCH}"
-        echo "QTHOME=${QTHOME}"
-        echo "QWTHOME=${QWTHOME}"
-        echo "QWTLIB=${QWTLIB}"
-        echo "QWTVERSION=${QWTVERSION}"
-        echo "EPICSINCLUDE=${EPICSINCLUDE}"
-        echo "EPICSLIB=${EPICSLIB}"
-        echo "EPICSEXTENSIONS=${EPICSEXTENSIONS}"
-        echo "QTCONTROLS_LIBS=${QTCONTROLS_LIBS}"
-        echo "CAQTDM_COLLECT=${CAQTDM_COLLECT}"
-        echo "QTBASE=${QTBASE}"
-        echo "CAQTDM_CA_ARCHIVELIBS=${CAQTDM_CA_ARCHIVELIBS}"
-        echo "CAQTDM_LOGGING_ARCHIVELIBS=${CAQTDM_LOGGING_ARCHIVELIBS}"
-        echo "QTDM_LIBINSTALL=${QTDM_LIBINSTALL}"
-        echo "QTDM_BININSTALL=${QTDM_BININSTALL}"
-        echo "PYTHONINCLUDE=${PYTHONINCLUDE}"
-        echo "PYTHONLIB=${PYTHONLIB}"
-
-
-    - name: Run build process
-      run: |
-        cd "$srcdir"
-
-        git config --global --add safe.directory $(pwd)
-
-        # Create make files
-        qmake6 ./all.pro
-
-        # Build the project. The output binaries, plugins, and custom shared libs
-        # are expected to be in ${srcdir}/binaries/
-        make -j $(nproc)
-      shell: bash
-
-    - name: Collect build artifacts (executables and libs)
-      run: |
-        export ARTIFACT_DIR="$(pwd)/caqtdm-build-output"
-        mkdir -p "$ARTIFACT_DIR"
-
-        echo "Collecting executables and shared libraries from ${srcdir}/binaries into output directory..."
-        # Copy all contents of the binaries directory, which should contain the built application and its plugins/libs
-        if [ -d "$srcdir/binaries" ]; then
-          cp -r "$srcdir/binaries/"* "$ARTIFACT_DIR/" || true
-        else
-          echo "Warning: No 'binaries' directory found at $srcdir. The build might not have produced expected outputs."
-        fi
-
-        if [ -d "$srcdir/caqtdm/caQtDM_QtControls/doc" ]; then
-            echo "Copying documentation from build directory into output..."
-            mkdir -p "$ARTIFACT_DIR/doc"
-            cp -r "$srcdir/caqtdm/caQtDM_QtControls/doc/"* "$ARTIFACT_DIR/doc/" || true
-        fi
-
-        echo "Collected artifacts are in $ARTIFACT_DIR"
-
-        # Display dynamic dependencies of the main executable for verification
-        # The 'caQtDM' executable is expected in the root of the 'binaries' output
-        if [ -f "$ARTIFACT_DIR/caQtDM" ]; then
-          echo ""
-          echo "--- Dynamic dependencies of caQtDM (via ldd) ---"
-          ldd "$ARTIFACT_DIR/caQtDM" || echo "ldd command failed or caQtDM not found/executable."
-          echo "------------------------------------------------"
-          echo "All dependencies (Qt, EPICS, QWT, ZeroMQ, glibc, etc.) are dynamically linked."
-        else
-          echo "Warning: 'caQtDM' executable not found in '$ARTIFACT_DIR' to run ldd. Check build output."
-        fi
-      shell: bash
-
-    - name: Upload caQtDM build output
-      uses: actions/upload-artifact@v4
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v7
       with:
-        name: caqtdm-build-output-current
-        path: ./caqtdm-build-output
-        retention-days: 7
+        name: caqtdm-archlinux-package
+        path: caQtDM_Viewer/package/archlinux/caqtdm/*.pkg.tar.*
+
+    - name: Upload epics-base package artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: epics-base-archlinux-package
+        path: caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -53,11 +53,25 @@ jobs:
         useradd -m -s /bin/bash builder
         chown -R builder:builder "$GITHUB_WORKSPACE"
 
+    - name: Cache epics-base package
+      id: cache-epics-base
+      uses: actions/cache@v5
+      with:
+        path: caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
+        key: epics-base-pkg-${{ runner.os }}-${{ hashFiles('caQtDM_Viewer/package/archlinux/epics-base/PKGBUILD', 'caQtDM_Viewer/package/archlinux/epics-base/*.patch') }}
+
     - name: Build package from PKGBUILD
       run: |
         set -euo pipefail
         WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
-        sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
+
+        if ls "$WORKSPACE_DIR"/caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.* >/dev/null 2>&1; then
+          echo "Using cached epics-base package"
+        else
+          echo "No cached epics-base package found, building..."
+          sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/epics-base" && makepkg --noconfirm --cleanbuild'
+        fi
+
         pacman -U --noconfirm caQtDM_Viewer/package/archlinux/epics-base/*.pkg.tar.*
         sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
 

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -53,6 +53,17 @@ jobs:
         useradd -m -s /bin/bash builder
         chown -R builder:builder "$GITHUB_WORKSPACE"
 
+    - name: Optimize makepkg.conf for parallel building
+      run: |
+        set -euo pipefail
+        NUM_CORES=$(nproc)
+        echo "Detected ${NUM_CORES} CPU cores. Optimizing /etc/makepkg.conf..."
+        grep -v "^MAKEFLAGS=" /etc/makepkg.conf > /tmp/makepkg.conf.tmp
+        echo "MAKEFLAGS=\"-j${NUM_CORES}\"" >> /tmp/makepkg.conf.tmp
+        mv /tmp/makepkg.conf.tmp /etc/makepkg.conf
+        echo "Current MAKEFLAGS in /etc/makepkg.conf:"
+        grep "MAKEFLAGS" /etc/makepkg.conf
+
     - name: Cache epics-base package
       id: cache-epics-base
       uses: actions/cache@v5

--- a/.github/workflows/build-caqtdm.yml
+++ b/.github/workflows/build-caqtdm.yml
@@ -110,7 +110,7 @@ jobs:
       run: |
         set -euo pipefail
         WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
-        sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
+        sudo -u builder env WORKSPACE_DIR="$WORKSPACE_DIR" CAQTDM_REPO_URL="file://$WORKSPACE_DIR" bash -lc 'cd "$WORKSPACE_DIR/caQtDM_Viewer/package/archlinux/caqtdm" && makepkg --noconfirm --cleanbuild'
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v7

--- a/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
+++ b/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Julian Houba <info at craftingdragon dot ch>
 _pkgsrc=caqtdm
+_caqtdm_repo="${CAQTDM_REPO_URL:-https://github.com/caqtdm/caqtdm.git}"
 pkgname='caqtdm-git'
 pkgver=4.6.0.r5463.g24d9eb2
 pkgrel=1
@@ -14,6 +15,8 @@ depends=(
     'python'
     'qt6-base'
     'qt6-opcua'
+    'qt6-positioning'
+    'qt6-serialbus'
     'qt6-tools'
     'qwt'
     'zeromq'
@@ -24,7 +27,7 @@ makedepends=(
 )
 provides=("caqtdm=${pkgver}")
 conflicts=('caqtdm')
-source=("$_pkgsrc::git+https://github.com/caqtdm/caqtdm.git")
+source=("$_pkgsrc::git+${_caqtdm_repo}")
 sha256sums=('SKIP')
 
 pkgver() {
@@ -49,6 +52,9 @@ build() {
     export ZMQ=/usr
     export ZMQINC=/usr/include
     export ZMQLIB=/usr/lib
+    export CAQTDM_OPCUA=1
+    export CAQTDM_MODBUS=1
+    export CAQTDM_GPS=1
     export CAQTDM_NORPATH=1
     export EPICS_HOST_ARCH="linux-${CARCH}"
     export QTHOME=/usr

--- a/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
+++ b/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
@@ -1,171 +1,151 @@
-# Maintainer: Julian Houba <craftingdragon007 at outlook dot com>
-pkgname='caqtdm'
-pkgver=4.6.0
-pkgrel=2
-pkgdesc="caQtDM is a popular Epics framework for developing panels"
-arch=('any')
-url="http://caqtdm.github.io/"
-license=('GPL')
-depends=('qt6-base' 'qt6-tools' 'qwt-qt6' 'epics-base' 'zeromq' 'python' 'bash' 'glibc' 'gcc-libs')
-makedepends=('patch' 'make' 'gcc' 'git')
-source=("git+https://github.com/caqtdm/caqtdm.git#tag=v4.5.0-rc2" 
-        "fix_qwt_static_cast_gcc.patch")
-sha512sums=('SKIP' 'f279be12d4c2d9a948990f5a01274ca414f76b79b5b181743029a60334a4db4a2d120772c23dfbacb811aa48ce587a3ceceafb5e54d9cf3274694bf733dd767c')
+# Maintainer: Julian Houba <info at craftingdragon dot ch>
+_pkgsrc=caqtdm
+pkgname='caqtdm-git'
+pkgver=4.6.0.r5463.g24d9eb2
+pkgrel=1
+pkgdesc='caQtDM is a popular Epics framework for developing panels'
+arch=('x86_64')
+url='https://caqtdm.github.io/'
+license=('GPL-3.0-or-later')
+depends=(
+    'epics-base'
+    'gcc-libs'
+    'glibc'
+    'python'
+    'qt6-base'
+    'qt6-tools'
+    'qwt'
+    'zeromq'
+)
+makedepends=(
+    'git'
+    'qt6-5compat'
+)
+provides=("caqtdm=${pkgver}")
+conflicts=('caqtdm')
+source=("$_pkgsrc::git+https://github.com/caqtdm/caqtdm.git")
+sha256sums=('SKIP')
 
-prepare() {
-    # Write environment variables to env_config.sh
-    cat > "${srcdir}/env_config.sh" << 'EOF'
-export QWTLIBNAME=qwt-qt6
-export QWTINCLUDE=/usr/include/qwt-qt6
-export EPICS_BASE=/usr/lib/epics
-export PYTHONVERSION=$(python --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1-2)
-export ZMQ=/usr
-export ZMQINC=$ZMQ/include
-export ZMQLIB=$ZMQ/lib
-export QTDM_RPATH=/opt/caqtdm/lib/qt6
-
-if [ -z "$CARCH" ]; then
-    export CARCH=$(uname -m)
-fi
-
-export EPICS_HOST_ARCH=linux-${CARCH}
-
-export QTHOME=/usr
-export QWTHOME=/usr
-export QWTLIB=${QWTHOME}/lib
-export QWTVERSION=6.1
-export EPICSINCLUDE=${EPICS_BASE}/include
-export EPICSLIB=${EPICS_BASE}/lib/$EPICS_HOST_ARCH
-export EPICSEXTENSIONS=${EPICS_BASE}/extensions
-export QTCONTROLS_LIBS=${srcdir}/binaries
-export CAQTDM_COLLECT=${srcdir}/binaries
-export QTBASE=${QTCONTROLS_LIBS}
-export CAQTDM_CA_ARCHIVELIBS=${srcdir}/binaries/
-export CAQTDM_LOGGING_ARCHIVELIBS=${srcdir}/binaries
-export QTDM_LIBINSTALL=$EPICSEXTENSIONS/lib/$EPICS_HOST_ARCH
-export QTDM_BININSTALL=$EPICSEXTENSIONS/bin/$EPICS_HOST_ARCH
-export PYTHONINCLUDE=/usr/include/python$PYTHONVERSION
-export PYTHONLIB=/usr/lib/
-EOF
-
-    # Patch broken files
-    patch --forward --strip=1 --input="${srcdir}/fix_qwt_static_cast_gcc.patch"
+pkgver() {
+    cd "$srcdir/$_pkgsrc/caQtDM_Viewer"
+    local _ver _rev _hash
+    _ver=$(grep -oP 'CAQTDM_VERSION\s*=\s*\K[Vv]?[\d.]+' qtdefs.pri | sed 's/^[Vv]//')
+    _rev=$(git rev-list --count HEAD)
+    _hash=$(git rev-parse --short=7 HEAD)
+    printf "%s.r%s.g%s" "$_ver" "$_rev" "$_hash"
 }
 
 build() {
-    cd "$srcdir/caqtdm"
-    # Source the environment variables
-    source "${srcdir}/env_config.sh"
-    # Create make files
+    cd "$srcdir/$_pkgsrc"
+
+    local _pythonver
+    _pythonver=$(python --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1-2)
+
+    export QWTLIBNAME=qwt
+    export QWTINCLUDE=/usr/include/qwt
+    export EPICS_BASE=/usr/lib/epics
+    export PYTHONVERSION="$_pythonver"
+    export ZMQ=/usr
+    export ZMQINC=/usr/include
+    export ZMQLIB=/usr/lib
+    export CAQTDM_NORPATH=1
+    export EPICS_HOST_ARCH="linux-${CARCH}"
+    export QTHOME=/usr
+    export QWTHOME=/usr
+    export QWTLIB=/usr/lib
+    export QWTVERSION=6.1
+    export EPICSINCLUDE="$EPICS_BASE/include"
+    export EPICSLIB="$EPICS_BASE/lib/$EPICS_HOST_ARCH"
+    export EPICSEXTENSIONS="$EPICS_BASE/extensions"
+    export QTCONTROLS_LIBS="$srcdir/binaries"
+    export CAQTDM_COLLECT="$srcdir/binaries"
+    export QTBASE="$QTCONTROLS_LIBS"
+    export CAQTDM_CA_ARCHIVELIBS="$srcdir/binaries/"
+    export CAQTDM_LOGGING_ARCHIVELIBS="$srcdir/binaries"
+    export QTDM_LIBINSTALL="$EPICSEXTENSIONS/lib/$EPICS_HOST_ARCH"
+    export QTDM_BININSTALL="$EPICSEXTENSIONS/bin/$EPICS_HOST_ARCH"
+    export PYTHONINCLUDE="/usr/include/python$_pythonver"
+    export PYTHONLIB=/usr/lib/
+
     qmake6 ./all.pro
-    # Build the project
     make
 }
 
 package() {
-    cd "$srcdir/caqtdm"
+    cd "$srcdir/$_pkgsrc"
 
-    mkdir -p "${pkgdir}/opt/caqtdm/doc"
-    mkdir -p "${pkgdir}/opt/caqtdm/lib/qt6"
-    mkdir -p "${pkgdir}/usr/bin"
-    mkdir -p "${pkgdir}/usr/include"
-    mkdir -p "${pkgdir}/usr/include/caqtdm"
-    mkdir -p "${pkgdir}/usr/include/caqtdm/plugins"
-    mkdir -p "${pkgdir}/usr/include/caqtdm/caQtDM_Plugins"
-    mkdir -p "${pkgdir}/usr/lib"
-    mkdir -p "${pkgdir}/usr/lib/qt6/plugins/designer/"
+    install -dm755 \
+        "$pkgdir/opt/caqtdm/doc" \
+        "$pkgdir/opt/caqtdm/lib/qt6" \
+        "$pkgdir/usr/bin" \
+        "$pkgdir/usr/include/caqtdm/plugins" \
+        "$pkgdir/usr/include/caqtdm/caQtDM_Plugins" \
+        "$pkgdir/usr/lib/qt6/plugins/designer" \
+        "$pkgdir/etc/ld.so.conf.d"
 
-    
-    # Install binaries
-    cp -r $srcdir/binaries/* $pkgdir/opt/caqtdm/lib/qt6
-    echo "#!/bin/bash" > $pkgdir/opt/caqtdm/lib/qt6/caqtdm
+    cp -r "$srcdir/binaries/"* "$pkgdir/opt/caqtdm/lib/qt6/"
 
-    # Create caQtDM script
-    echo "caQtDM -style Fusion \"\$@\" &" > $pkgdir/opt/caqtdm/lib/qt6/caqtdm
+    install -Dm755 /dev/stdin "$pkgdir/opt/caqtdm/lib/qt6/caqtdm" << 'EOF'
+#!/bin/bash
+caQtDM -style Fusion "$@" &
+EOF
 
-    # Make the script executable
-    chmod +x $pkgdir/opt/caqtdm/lib/qt6/caqtdm
+    install -Dm755 /dev/stdin "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer" << 'EOF'
+#!/bin/bash
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+CAQTDM_HOME="$DIR/../.."
 
-    # Create qt designer script
-    echo "#!/bin/bash" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "SOURCE=\"\${BASH_SOURCE[0]}\"" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "while [ -h \"\$SOURCE\" ]; do # resolve \$SOURCE until the file is no longer a symlink" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "  DIR=\"\$( cd -P \"\$( dirname \"\$SOURCE\" )\" && pwd )\"" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo     "  SOURCE=\"\$(readlink \"\$SOURCE\")\"" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "  [[ \$SOURCE != /* ]] && SOURCE=\"\$DIR/\$SOURCE\" # if \$SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "done" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "DIR=\"\$( cd -P \"\$( dirname \"\$SOURCE\" )\" && pwd )\"" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "CAQTDM_HOME=\$DIR/../.." >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "# Register help" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "assistant6 -register \$CAQTDM_HOME/doc/caQtDM.qch" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "export QT_PLUGIN_PATH=\$CAQTDM_HOME/lib/qt6" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
-    echo "designer6 \$@" >> "$pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer"
+assistant6 -register "$CAQTDM_HOME/doc/caQtDM.qch"
+export QT_PLUGIN_PATH="$CAQTDM_HOME/lib/qt6"
+designer6 "$@"
+EOF
 
-    # Make the script executable
-    chmod +x $pkgdir/opt/caqtdm/lib/qt6/caqtdm_designer
+    install -Dm644 /dev/stdin "$pkgdir/etc/ld.so.conf.d/caqtdm.conf" << 'EOF'
+/opt/caqtdm/lib/qt6
+/opt/caqtdm/lib/qt6/designer
+/opt/caqtdm/lib/qt6/controlsystems
+EOF
 
+    ln -sf /opt/caqtdm/lib/qt6/caqtdm         "$pkgdir/usr/bin/caqtdm"
+    ln -sf /opt/caqtdm/lib/qt6/caQtDM         "$pkgdir/usr/bin/caQtDM"
+    ln -sf /opt/caqtdm/lib/qt6/adl2ui          "$pkgdir/usr/bin/adl2ui"
+    ln -sf /opt/caqtdm/lib/qt6/edl2ui          "$pkgdir/usr/bin/edl2ui"
+    ln -sf /opt/caqtdm/lib/qt6/caqtdm_designer "$pkgdir/usr/bin/caqtdm_designer"
 
-    # Create symlinks
-    ln -sfv /opt/caqtdm/lib/qt6/caqtdm $pkgdir/usr/bin/caqtdm
-    ln -sfv /opt/caqtdm/lib/qt6/caQtDM $pkgdir/usr/bin/caQtDM
-    ln -sfv /opt/caqtdm/lib/qt6/adl2ui $pkgdir/usr/bin/adl2ui
-    ln -sfv /opt/caqtdm/lib/qt6/edl2ui $pkgdir/usr/bin/edl2ui
-    ln -sfv /opt/caqtdm/lib/qt6/caqtdm_designer $pkgdir/usr/bin/caqtdm_designer
+    local _designerdir="$pkgdir/usr/lib/qt6/plugins/designer"
+    ln -sf /opt/caqtdm/lib/qt6/designer/libqtcontrols_controllers_plugin.so \
+        "$_designerdir/"
+    ln -sf /opt/caqtdm/lib/qt6/designer/libqtcontrols_graphics_plugin.so \
+        "$_designerdir/"
+    ln -sf /opt/caqtdm/lib/qt6/designer/libqtcontrols_monitors_plugin.so \
+        "$_designerdir/"
+    ln -sf /opt/caqtdm/lib/qt6/designer/libqtcontrols_utilities_plugin.so \
+        "$_designerdir/"
 
-    ln -sfv /opt/caqtdm/lib/qt6/designer/libqtcontrols_controllers_plugin.so $pkgdir/usr/lib/qt6/plugins/designer/
-    ln -sfv /opt/caqtdm/lib/qt6/designer/libqtcontrols_graphics_plugin.so $pkgdir/usr/lib/qt6/plugins/designer/
-    ln -sfv /opt/caqtdm/lib/qt6/designer/libqtcontrols_monitors_plugin.so $pkgdir/usr/lib/qt6/plugins/designer/
-    ln -sfv /opt/caqtdm/lib/qt6/designer/libqtcontrols_utilities_plugin.so $pkgdir/usr/lib/qt6/plugins/designer/
-    
+    install -Dm644 -t "$pkgdir/usr/include/caqtdm/" \
+        "$srcdir/$_pkgsrc/caQtDM_QtControls/src/"*.h
+    install -Dm644 -t "$pkgdir/usr/include/caqtdm/" \
+        "$srcdir/$_pkgsrc/caQtDM_Lib/src/"*.h
+    install -Dm644 -t "$pkgdir/usr/include/caqtdm/" \
+        "$srcdir/$_pkgsrc/caQtDM_Viewer/src/"*.h
+    install -Dm644 -t "$pkgdir/usr/include/caqtdm/plugins/" \
+        "$srcdir/$_pkgsrc/caQtDM_QtControls/plugins/"*.h
+    install -Dm644 -t "$pkgdir/usr/include/caqtdm/caQtDM_Plugins/" \
+        "$srcdir/$_pkgsrc/caQtDM_Lib/caQtDM_Plugins/"*.h
 
+    find "$srcdir/$_pkgsrc/caQtDM_QtControls/src" -maxdepth 1 \
+        -type f ! -name '*.*' \
+        ! -iname '*license*' ! -iname '*copying*' ! -iname '*readme*' \
+        -exec install -Dm644 -t "$pkgdir/usr/include/caqtdm/" {} +
 
-    # Install include files and docs
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/*.h     $pkgdir/usr/include/caqtdm
-
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caApplyNumeric   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caBitnames   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caByte   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caCalc   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caCamera   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caCartesianPlot   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caChoice   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caFrame   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caGauge   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caGraphics   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caImage   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caLabel   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caLed   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caLineEdit   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caMenu   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caMessageButton   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caMimeDisplay   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caMultiLineString   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caNumeric   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caSlider   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caSpinbox   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caStripPlot   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caTextEntry   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caThermo   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caToggleButton   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/caWaterfallPlot   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/EApplyButton   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/EArrow   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/EFlag   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/EGauge   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/ELabel   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/ESimpleLabel   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/EWidget   $pkgdir/usr/include/caqtdm
-    cp $srcdir/caqtdm/caQtDM_QtControls/src/QtControls   $pkgdir/usr/include/caqtdm
-
-    cp $srcdir/caqtdm/caQtDM_QtControls/plugins/*.h  $pkgdir/usr/include/caqtdm/plugins
-
-    cp $srcdir/caqtdm/caQtDM_Lib/src/*.h     $pkgdir/usr/include/caqtdm
-        
-    cp $srcdir/caqtdm/caQtDM_Lib/caQtDM_Plugins/*.h     $pkgdir/usr/include/caqtdm/caQtDM_Plugins
-
-    cp $srcdir/caqtdm/caQtDM_Viewer/src/*.h     $pkgdir/usr/include/caqtdm
-        
-    cp $srcdir/caqtdm/caQtDM_QtControls/doc/*.qch     $pkgdir/opt/caqtdm/doc
-    cp $srcdir/caqtdm/caQtDM_QtControls/doc/*.html     $pkgdir/opt/caqtdm/doc
-    cp $srcdir/caqtdm/caQtDM_QtControls/doc/*.css     $pkgdir/opt/caqtdm/doc
+    install -Dm644 -t "$pkgdir/opt/caqtdm/doc/" \
+        "$srcdir/$_pkgsrc/caQtDM_QtControls/doc/"*.qch \
+        "$srcdir/$_pkgsrc/caQtDM_QtControls/doc/"*.html \
+        "$srcdir/$_pkgsrc/caQtDM_QtControls/doc/"*.css
 }

--- a/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
+++ b/caQtDM_Viewer/package/archlinux/caqtdm/PKGBUILD
@@ -13,6 +13,7 @@ depends=(
     'glibc'
     'python'
     'qt6-base'
+    'qt6-opcua'
     'qt6-tools'
     'qwt'
     'zeromq'

--- a/caQtDM_Viewer/package/archlinux/epics-base/PKGBUILD
+++ b/caQtDM_Viewer/package/archlinux/epics-base/PKGBUILD
@@ -1,36 +1,33 @@
-# Maintainer: Julian Houba <craftingdragon007 at outlook dot com>
+# Maintainer: Julian Houba <info at craftingdragon dot ch>
 # Contributor: Grey Christoforo <first name at last name dot net>
 # Contributor: Rafael Silva <perigoso at riseup dot net>
 
 pkgname='epics-base'
-pkgver=7.0.9
-pkgrel=2
+pkgver=7.0.10
+pkgrel=1
+_pkgsrc='epics-base'
 pkgdesc="Experimental Physics and Industrial Control System"
-arch=('any')
+arch=('x86_64')
 url="https://epics-controls.org"
-license=('custom:EPICS Open License')
+license=('LicenseRef-EPICS-Open-License')
 groups=('epics')
 depends=('readline' 'ncurses' 'perl')
-makedepends=()
-source=("https://epics-controls.org/download/base/base-${pkgver}.tar.gz"{,.asc}
+source=("${_pkgsrc}::git+https://github.com/epics-base/epics-base.git#tag=R${pkgver}"
         '01_install_permissions.patch'
         '02_no_rpath.patch'
-        '03_new_gcc_version_fix.patch'
 )
-sha512sums=('40accd1954ba750d250c88ef60289e99921d30235180824575a6b82325f10fe6d920b740e6895da9908be5465a2fa9b8004b8f004694e01f38cdc63e8c9ed430'
-            'SKIP'
+sha512sums=('SKIP'
             '8d8ea744e1bd011c0a01c645a37cd29c420830389ce340820975ea798c6138ce28d7d5e066fe503025fb353a2e19c1a33169a3d5777414e60b42eb5b3874091a'
-            '394b023fe3003e61701c8c31d44c17281297a3b67f3bbe604e9191f38267986c34b06fe24eae5e778a29b466b022bdce5d4d0f4061da9c91a44467f1e0d266a3'
-            'd6e52695cb34647ffa4105f648898bb31dd5f77d67e8bf02e3f6650225ea75399383480278a9e63f0ee608fb1487c98702d27297b90cb8827b2c5377d761a113')
-validpgpkeys=('4B688BF5CAF9452CBD5BE86FD306120EEACB4576') # Andrew Johnson (Argonne)
+            '394b023fe3003e61701c8c31d44c17281297a3b67f3bbe604e9191f38267986c34b06fe24eae5e778a29b466b022bdce5d4d0f4061da9c91a44467f1e0d266a3')
 
 prepare() {
-    cd "base-${pkgver}"
+    cd "${_pkgsrc}"
+
+    git submodule update --init --recursive
 
     # apply patches
     patch --forward --strip=1 --input="${srcdir}/01_install_permissions.patch"
     patch --forward --strip=1 --input="${srcdir}/02_no_rpath.patch"
-    patch --forward --strip=1 --input="${srcdir}/03_new_gcc_version_fix.patch"
 
     # install files to staging area
     echo "INSTALL_LOCATION=${srcdir}/staging/usr/lib/epics" >'configure/CONFIG_SITE.local'
@@ -43,7 +40,7 @@ prepare() {
 }
 
 build() {
-    cd "base-${pkgver}"
+    cd "${_pkgsrc}"
 
     # get the EPICS_HOST_ARCH and set it as an environment variable
     export EPICS_HOST_ARCH=$(cat "${srcdir}/EPICS_HOST_ARCH")
@@ -89,7 +86,7 @@ package() {
     # install bin files and link non internal binaries to system path
     install -dm755 "${EPICS_BASE}/bin/${EPICS_HOST_ARCH}" "${pkgdir}/usr/bin"
     cp -P "bin/${EPICS_HOST_ARCH}"/* "${EPICS_BASE}/bin/${EPICS_HOST_ARCH}"
-    for bin in caget caput cainfo camonitor caRepeater casw pvget pvinfo pvlist pvput; do
+    for bin in caget caput cainfo camonitor caRepeater casw pvget pvinfo pvlist pvput caEventRate; do
         ln -sr "${EPICS_BASE}/bin/${EPICS_HOST_ARCH}/${bin}" "${pkgdir}/usr/bin"
     done
 
@@ -98,7 +95,7 @@ package() {
     done
 
     # install include files and link them to the system include path
-    install -dm644 "${pkgdir}/usr/include/epics"
+    install -dm755 "${pkgdir}/usr/include/epics"
     cp -r include "${EPICS_BASE}"
     ln -sr -t "${pkgdir}/usr/include/epics" "${EPICS_BASE}/include"
 
@@ -110,20 +107,19 @@ package() {
     done
 
     # install pkgconfig files to the system path
-    install -Dm755 -t "${pkgdir}/usr/lib/pkgconfig" lib/pkgconfig/epics-base{,"-${EPICS_HOST_ARCH}"}.pc
+    install -Dm644 -t "${pkgdir}/usr/lib/pkgconfig" lib/pkgconfig/epics-base{,"-${EPICS_HOST_ARCH}"}.pc
 
     # install docs
-    install -dm644 "${pkgdir}/usr/share/doc/epics"
+    install -dm755 "${pkgdir}/usr/share/doc/epics"
     cp -r html "${pkgdir}/usr/share/doc/epics"
 
     # install LICENSE file
-    install -Dm644 "${srcdir}/base-${pkgver}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 "${srcdir}/${_pkgsrc}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 
     # install a env file to set the EPICS_HOST_ARCH and EPICS_BASE
-    install -dm755 "${pkgdir}/usr/lib/environment.d"
-    echo "# Entries in this file set the host environment for EPICS" >"${pkgdir}/usr/lib/environment.d/10-epics-base.conf"
-    echo "EPICS_HOST_ARCH=\"${EPICS_HOST_ARCH}\"" >>"${pkgdir}/usr/lib/environment.d/10-epics-base.conf"
-    echo "EPICS_BASE=\"/usr/lib/epics\"" >>"${pkgdir}/usr/lib/environment.d/10-epics-base.conf"
+    printf '# Entries in this file set the host environment for EPICS\nEPICS_HOST_ARCH="%s"\nEPICS_BASE="/usr/lib/epics"\n' \
+        "${EPICS_HOST_ARCH}" |
+        install -Dm644 /dev/stdin "${pkgdir}/usr/lib/environment.d/10-epics-base.conf"
 
     # Patch epics config_site local install location to current folder (.)
     sed -i "s|${srcdir}/staging/usr/lib/epics|./usr/lib/epics|g" "${pkgdir}/usr/lib/epics/configure/CONFIG_SITE.local"

--- a/caQtDM_Viewer/package/archlinux/qt6-opcua/PKGBUILD
+++ b/caQtDM_Viewer/package/archlinux/qt6-opcua/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Julian Houba <info@craftingdragon.ch>
+# Contributor: Vaclav Kubernat <sir.venceslas@gmail.com> (maintainer of qt5 version)
+
+pkgname=qt6-opcua
+pkgver=6.11.0
+pkgrel=1
+pkgdesc='Qt 6 wrapper for existing OPC UA stacks'
+arch=('x86_64' 'aarch64')
+url='https://www.qt.io'
+license=('GPL3' 'LGPL3' 'FDL' 'custom')
+depends=('qt6-base' 'openssl')
+makedepends=('git' 'cmake' 'ninja' 'qt6-declarative')
+groups=('qt6')
+_pkgfqn=qtopcua
+source=("https://github.com/qt/$_pkgfqn/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('0d676bd8428b5a8157b713672a14c91fa0e0420bac70980e3f268e6f6008cbd6')
+
+build() {
+  cmake -B build -S "$_pkgfqn-$pkgver" -G Ninja \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DQT_FEATURE_open62541=ON \
+    -DQT_BUILD_EXAMPLES=OFF
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+
+  install -d "$pkgdir"/usr/share/licenses
+  ln -s /usr/share/licenses/qt6-base "$pkgdir"/usr/share/licenses/${pkgname}
+}


### PR DESCRIPTION
I updated the archlinux build pipeline so it produces an actual archlinux binary package.
In addition to that it now also builds the modbus, gps and opcua parts of caqtdm so gives more information about those parts.
The versioning of the caqtdm artifacts follows the archlinux standards for git packages.
Additionally I also use caching (for epics  and qt6-opcua) to speed up build time.
This new workflow also uses the qwt core package instead of the now defuncted aur package.
It also doesn't download PKGBUILD files from the aur, all PKGBUILD files are now in the archlinux packaging directory.