### PR TITLE
Added gradle caching action

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -196,6 +196,11 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
 


### PR DESCRIPTION
This adds a gradle caching action to the android build pipeline, reducing the need to download gradle and also prevent download timeouts for gradle in scheduled jobs