### PR TITLE
Fixed caInclude by reverting commenting out of caInclude layout

### DIFF
--- a/caQtDM_Lib/src/caqtdm_lib.cpp
+++ b/caQtDM_Lib/src/caqtdm_lib.cpp
@@ -2530,7 +2530,7 @@ void CaQtDM_Lib::HandleWidget(QWidget *w1, QString macro, bool firstPass, bool t
         thisPalette.setColor(QPalette::Light, thisLightColor);
         thisPalette.setColor(QPalette::Dark, thisDarkColor);
         thisPalette.setColor(QPalette::Window, thisFrameColor);
-        //if (m_boxLayout) includeWidget->setLayout(m_boxLayout);
+        if (m_boxLayout) includeWidget->setLayout(m_boxLayout);
         if (m_boxLayout) m_boxLayout->addWidget(frame);
 
         if(gridLayout) frame->setLayout(gridLayout);


### PR DESCRIPTION
The commenting out of this single line caused caIncludes to break and not be displayed at all