### PR TITLE
Properly handle shutdown and clean-up in logging

### DIFF
--- a/caQtDM_Plugins/internal/internal_plugin.cpp
+++ b/caQtDM_Plugins/internal/internal_plugin.cpp
@@ -48,7 +48,6 @@ InternalPlugin::InternalPlugin()
 
 InternalPlugin::~InternalPlugin()
 {
-    if(timer) timer->deleteLater();
     qDeleteAll(channels);
     channels.clear();
 }

--- a/caQtDM_UnitTests/tst_viewer/tst_logging/tst_generalloghandler.cpp
+++ b/caQtDM_UnitTests/tst_viewer/tst_logging/tst_generalloghandler.cpp
@@ -75,21 +75,8 @@ void TestGeneralLogHandler::cleanup()
 {
     // code to be executed after each test function
 
-    // Reverse everything done in GeneralLogHandler::initialize()
+    GeneralLogHandler::shutdown();
     qInstallMessageHandler(nullptr);
-
-    QMutexLocker locker(&GeneralLogHandler::s_mutex);
-    for (auto existingLogHandler : GeneralLogHandler::s_logHandlers) {
-        delete existingLogHandler;
-    }
-    GeneralLogHandler::s_logHandlers.clear();
-
-    if (GeneralLogHandler::s_logHandlersThread) {
-        GeneralLogHandler::s_logHandlersThread->quit();
-        GeneralLogHandler::s_logHandlersThread->wait();
-        delete GeneralLogHandler::s_logHandlersThread;
-        GeneralLogHandler::s_logHandlersThread = Q_NULLPTR;
-    }
 }
 
 void TestGeneralLogHandler::injectsMessageHandlerAndReturnsPrevious()
@@ -167,6 +154,24 @@ void TestGeneralLogHandler::fatalMessageFlushesHandler()
     GeneralLogHandler::messageHandler(QtFatalMsg, {}, "fatal");
 
     QCOMPARE(handler->flushCalls, 1);
+}
+
+void TestGeneralLogHandler::shutdownRestoresPreviousHandlerAndIsIdempotent()
+{
+    qInstallMessageHandler(mockMessageHandler);
+    GeneralLogHandler::initialize();
+
+    GeneralLogHandler::shutdown();
+
+    QtMessageHandler currentHandler = qInstallMessageHandler(nullptr);
+    QVERIFY(currentHandler == mockMessageHandler);
+    QVERIFY(GeneralLogHandler::s_logHandlers.isEmpty());
+    QVERIFY(GeneralLogHandler::s_logHandlersThread == Q_NULLPTR);
+    QVERIFY(!GeneralLogHandler::s_isInitialized);
+
+    GeneralLogHandler::shutdown();
+    QVERIFY(GeneralLogHandler::s_logHandlers.isEmpty());
+    QVERIFY(GeneralLogHandler::s_logHandlersThread == Q_NULLPTR);
 }
 
 void TestGeneralLogHandler::logHandlersAreInitializedFromEnv()

--- a/caQtDM_UnitTests/tst_viewer/tst_logging/tst_generalloghandler.h
+++ b/caQtDM_UnitTests/tst_viewer/tst_logging/tst_generalloghandler.h
@@ -44,6 +44,7 @@ private slots:
     void callsHandler();
     void fatalMessageFlushesHandler();
     void logHandlersAreInitializedFromEnv();
+    void shutdownRestoresPreviousHandlerAndIsIdempotent();
 };
 
 #endif // TST_GENERALLOGHANDLER_H

--- a/caQtDM_Viewer/src/caQtDM.cpp
+++ b/caQtDM_Viewer/src/caQtDM.cpp
@@ -529,6 +529,9 @@ int main(int argc, char *argv[])
 
             if (web_launcher_file.isNull()) {
                 printf("caQtDM -- Error: Web launcher file not found, exiting...");
+#ifndef CAQTDM_NO_CUSTOM_LOGHANDLER
+                GeneralLogHandler::shutdown();
+#endif
                 return 1;
             }
         }
@@ -709,6 +712,10 @@ int main(int argc, char *argv[])
         exitCode = EXIT_FAILURE;
         qCCritical(caQtDMLog) << e.what();
     }
+
+#ifndef CAQTDM_NO_CUSTOM_LOGHANDLER
+    GeneralLogHandler::shutdown();
+#endif
 
     return exitCode;
 }

--- a/caQtDM_Viewer/src/logging/generalloghandler.cpp
+++ b/caQtDM_Viewer/src/logging/generalloghandler.cpp
@@ -43,6 +43,8 @@
 QMutex GeneralLogHandler::s_mutex;
 QList<AbstractLogHandler *> GeneralLogHandler::s_logHandlers;
 QThread *GeneralLogHandler::s_logHandlersThread = Q_NULLPTR;
+QtMessageHandler GeneralLogHandler::s_previousMessageHandler = Q_NULLPTR;
+bool GeneralLogHandler::s_isInitialized = false;
 qint64 GeneralLogHandler::s_processId = -1;
 
 Q_LOGGING_CATEGORY(generalLogHandlerLog, "caqtdm.logging.general")
@@ -56,6 +58,8 @@ QtMessageHandler GeneralLogHandler::initialize()
         // Was already initialized
         return previousHandler;
     }
+
+    s_previousMessageHandler = previousHandler;
 
     // Re-install previous handler for initialization logs
     qInstallMessageHandler(previousHandler);
@@ -128,8 +132,40 @@ QtMessageHandler GeneralLogHandler::initialize()
 
     // Now the custom handler is ready to accept logs, so install it again
     qInstallMessageHandler(GeneralLogHandler::messageHandler);
+    s_isInitialized = true;
 
     return previousHandler;
+}
+
+void GeneralLogHandler::shutdown()
+{
+    QMutexLocker locker(&s_mutex);
+
+    if (!s_isInitialized) {
+        return;
+    }
+
+    // Remove this handler before destroying objects which may emit Qt messages.
+    qInstallMessageHandler(s_previousMessageHandler);
+
+    for (auto logHandler : s_logHandlers) {
+        if (logHandler) {
+            logHandler->flush();
+            delete logHandler;
+        }
+    }
+    s_logHandlers.clear();
+
+    if (s_logHandlersThread) {
+        s_logHandlersThread->quit();
+        s_logHandlersThread->wait();
+        delete s_logHandlersThread;
+        s_logHandlersThread = Q_NULLPTR;
+    }
+
+    s_previousMessageHandler = Q_NULLPTR;
+    s_isInitialized = false;
+    s_processId = -1;
 }
 
 QStringList GeneralLogHandler::selectedLogHandlersFromEnv(const QString &defaultConfig)

--- a/caQtDM_Viewer/src/logging/generalloghandler.h
+++ b/caQtDM_Viewer/src/logging/generalloghandler.h
@@ -48,6 +48,11 @@ public:
      */
     static QtMessageHandler initialize();
     /**
+     * @brief Restores the previous Qt message handler and releases all logging resources.
+     * This function is idempotent and thread-safe.
+     */
+    static void shutdown();
+    /**
      * @brief The messageHandler called by Qt (after injected) to handle all qDebugs and similar.
      * This function is thread-safe.
      * @param type: The log level
@@ -74,6 +79,8 @@ private:
     static QMutex s_mutex;
     static QList<AbstractLogHandler *> s_logHandlers;
     static QThread *s_logHandlersThread;
+    static QtMessageHandler s_previousMessageHandler;
+    static bool s_isInitialized;
     static qint64 s_processId;
 };
 


### PR DESCRIPTION
This adds a shutdown routine to the general log handler.
This prevents a segfault from occuring if the logging is half destroyed during shutdown and a message is sent.