### PR TITLE
caImage: add crisp scaling default and smoothScaling property

### DIFF
--- a/caQtDM_QtControls/src/caimage.cpp
+++ b/caQtDM_QtControls/src/caimage.cpp
@@ -27,6 +27,7 @@
 #include "searchfile.h"
 #include "fileFunctions.h"
 #include <QPainter>
+#include <QResizeEvent>
 //#include <QElapsedTimer>
 
 Q_LOGGING_CATEGORY(caImageLog, "caqtdm.widgets.caimage")
@@ -41,6 +42,7 @@ caImage::caImage(QWidget* parent) : QWidget(parent)
     setVisibility(StaticV);
     timerId = 0;
     thisDelay = 500;
+    thisSmoothScaling = false;
 }
 
 caImage::~caImage() {
@@ -90,6 +92,7 @@ void caImage::init(const QString& filename, const bool isProvisional) {
         return;
     }
 
+    sourcePixmap = QPixmap();
     _animation = new QMovie(fileNameFound, 0, this);
     _animation->setCacheMode(QMovie::CacheAll);
     _animation->jumpToFrame(0);
@@ -97,18 +100,12 @@ void caImage::init(const QString& filename, const bool isProvisional) {
     delete s;
     if( _animation.isNull()) return;
     // display the movie
-    _container->setScaledContents(true);
-    _container->setMovie(_animation);
-
-    pixmap = _animation->currentPixmap();
-    pix    = _animation->currentPixmap();
-
-    if(thisAngle != 0) OnFrameChanged(0);
-
     _layout->setSpacing(0);
     SETMARGIN_QT456(_layout,0);
     _layout->addWidget(_container);
     setLayout(_layout);
+
+    renderCurrentFrame();
 
     setHidden(false);
 }
@@ -147,7 +144,7 @@ void caImage::setInvalid(QColor c)
       QString style = "color: rgb(%1, %2, %3); background-color: rgb(%4, %5, %6);";
       style = style.arg(c.red()).arg(c.green()).arg(c.blue()).arg(c.red()).arg(c.green()).arg(c.blue());
       _container->setStyleSheet(style);
-      _container->setMovie(NULL);
+      _container->clear();
       oldColor = c;
     }
 }
@@ -156,11 +153,11 @@ void caImage::setValid()
 {
     QColor c;
     if(oldColor == Qt::gray) return;
-    _container->setMovie(_animation);
     c = oldColor = Qt::gray;
     QString style = "color: rgb(%1, %2, %3); background-color: rgba(%4, %5, %6, %7);";
     style = style.arg(c.red()).arg(c.green()).arg(c.blue()).arg(c.red()).arg(c.green()).arg(c.blue()).arg(0);
     _container->setStyleSheet(style);
+    renderCurrentFrame();
 }
 
 void caImage::setFileName(QString filename, bool isProvisional)
@@ -199,29 +196,48 @@ void caImage::OnFrameChanged(int frame)
 {
     Q_UNUSED(frame)
     if( _animation.isNull()) return;
-    pixmap = pixmap.scaled(width(), height());
-    pixmap = _animation->currentPixmap();
-    if(thisAngle == 0) {
-        _container->setPixmap (pixmap);
-        return;
+    sourcePixmap = _animation->currentPixmap();
+    renderFrame(sourcePixmap);
+}
+
+void caImage::resizeEvent(QResizeEvent *e)
+{
+    QWidget::resizeEvent(e);
+    renderCurrentFrame();
+}
+
+void caImage::renderCurrentFrame()
+{
+    if(sourcePixmap.isNull()) {
+        if(_animation.isNull()) return;
+        sourcePixmap = _animation->currentPixmap();
+    }
+    renderFrame(sourcePixmap);
+}
+
+void caImage::renderFrame(const QPixmap &frame)
+{
+    if(_container.isNull() || frame.isNull()) return;
+
+    const QSize targetSize = contentsRect().size();
+    const QSize sourceSize = frame.size();
+    if(targetSize.isEmpty() || sourceSize.isEmpty()) return;
+
+    QPixmap rendered(targetSize);
+    rendered.fill(QColor::fromRgb(0, 0, 0, 0));
+
+    QPainter painter(&rendered);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, thisSmoothScaling);
+    painter.scale((qreal) targetSize.width() / sourceSize.width(),
+                  (qreal) targetSize.height() / sourceSize.height());
+
+    if(thisAngle != 0) {
+        // Keep the historical source-canvas pivot and clipping behaviour.
+        painter.translate(sourceSize.height()/2, sourceSize.height()/2);
+        painter.rotate(thisAngle);
+        painter.translate(-sourceSize.height()/2, -sourceSize.height()/2);
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QMatrix rm;
-#else
-    QTransform rm;
-#endif
-
-
-    pix.scaled(width(), height());
-    pix.fill(QColor::fromRgb(0, 0, 0, 0)); //pixmap transparent.
-    QPainter* p = new QPainter(&pix);
-    QSize size = pixmap.size();
-    p->translate(size.height()/2,size.height()/2);
-    p->rotate(thisAngle);
-    p->translate(-size.height()/2,-size.height()/2);
-    p->drawPixmap(0, 0, pixmap);
-    p->end();
-    delete p;
-    _container->setPixmap(pix);
+    painter.drawPixmap(0, 0, frame);
+    _container->setPixmap(rendered);
 }

--- a/caQtDM_QtControls/src/caimage.h
+++ b/caQtDM_QtControls/src/caimage.h
@@ -31,6 +31,7 @@
 #include <QMovie>
 #include <QMenu>
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <qtcontrols_global.h>
 #include "messageQueue.h"
 
@@ -44,6 +45,7 @@ class QTCON_EXPORT caImage : public QWidget
     Q_PROPERTY(int frame READ getFrame WRITE setFrame)
     Q_PROPERTY(int delayMilliseconds READ getDelay WRITE setDelay)
     Q_PROPERTY(int tiltAngle READ getAngle WRITE setAngle)
+    Q_PROPERTY(bool smoothScaling READ getSmoothScaling WRITE setSmoothScaling)
 
     // this will prevent user interference
     Q_PROPERTY(QString styleSheet READ styleSheet WRITE noStyle DESIGNABLE false)
@@ -71,6 +73,14 @@ public:
     void setAngle( int angle );
     int getAngle() {return thisAngle;}
 
+    bool getSmoothScaling() const {return thisSmoothScaling;}
+    void setSmoothScaling(bool smoothScaling) {
+        if(thisSmoothScaling != smoothScaling) {
+            thisSmoothScaling = smoothScaling;
+            renderCurrentFrame();
+        }
+    }
+
     int getFrameCount();
     void startMovie();
     void setInvalid(QColor c);
@@ -96,22 +106,26 @@ private slots:
 
 protected:
     virtual void timerEvent(QTimerEvent *e);
+    virtual void resizeEvent(QResizeEvent *e);
 
 private:
     void init(const QString& filename, const bool isProvisional);
+    void renderCurrentFrame();
+    void renderFrame(const QPixmap &frame);
 
     messageQueue *messagequeue;
     QPointer<QLabel> _container;
     QPointer<QMovie> _animation;
     QVBoxLayout* _layout;
     QString thisFileName;
-    QPixmap pixmap, pix;
+    QPixmap sourcePixmap;
     int thisFrame, thisDelay;
     int prevFrame;
     QString thisImageCalc;
     int timerId;
     QColor oldColor;
     int thisAngle;
+    bool thisSmoothScaling;
 };
 
 #endif

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.cpp
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.cpp
@@ -84,6 +84,32 @@ QImage renderedImage(caImage &image)
     return label->grab().toImage().convertToFormat(QImage::Format_ARGB32);
 }
 
+QPixmap labelPixmap(const QLabel *label)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const QPixmap *pixmap = label->pixmap();
+    return pixmap == Q_NULLPTR ? QPixmap() : *pixmap;
+#else
+    return label->pixmap(Qt::ReturnByValue);
+#endif
+}
+
+bool hasVisiblePixels(const QImage &image)
+{
+    for(int y = 0; y < image.height(); ++y) {
+        for(int x = 0; x < image.width(); ++x) {
+            if(qAlpha(image.pixel(x, y)) != 0) return true;
+        }
+    }
+    return false;
+}
+
+void verifyScalingMode(const QImage &image, const QSet<QRgb> &palette, bool smoothScaling)
+{
+    if(smoothScaling) QVERIFY(containsInterpolatedPixel(image, palette));
+    else QVERIFY(usesOnlyPalette(image, palette));
+}
+
 }
 
 void TestCaImage::smoothScalingPropertyAndPixels()
@@ -118,9 +144,143 @@ void TestCaImage::smoothScalingPropertyAndPixels()
     QCoreApplication::processEvents();
     const QImage smoothImage = renderedImage(image);
     QVERIFY(containsInterpolatedPixel(smoothImage, palette));
+
+    image.setSmoothScaling(false);
+    QCoreApplication::processEvents();
+    QVERIFY(usesOnlyPalette(renderedImage(image), palette));
 }
 
-void TestCaImage::resizeKeepsNearestNeighborRendering()
+void TestCaImage::smoothScalingBeforeLoad()
+{
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QSet<QRgb> palette;
+    const QString fileName = createScalingFixture(directory, palette);
+    QVERIFY(!fileName.isEmpty());
+
+    caImage image;
+    image.setSmoothScaling(true);
+    image.resize(7, 5);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+
+    QVERIFY(image.getSmoothScaling());
+    QVERIFY(containsInterpolatedPixel(renderedImage(image), palette));
+}
+
+void TestCaImage::resizeKeepsSelectedRendering_data()
+{
+    QTest::addColumn<bool>("smoothScaling");
+    QTest::newRow("nearest") << false;
+    QTest::newRow("smooth") << true;
+}
+
+void TestCaImage::resizeKeepsSelectedRendering()
+{
+    QFETCH(bool, smoothScaling);
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QSet<QRgb> palette;
+    const QString fileName = createScalingFixture(directory, palette);
+    QVERIFY(!fileName.isEmpty());
+
+    caImage image;
+    image.setSmoothScaling(smoothScaling);
+    image.resize(7, 5);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+
+    image.resize(13, 11);
+    QCoreApplication::processEvents();
+    const QImage resizedImage = renderedImage(image);
+    QCOMPARE(resizedImage.size(), image.contentsRect().size());
+    QCOMPARE(image.getSmoothScaling(), smoothScaling);
+    verifyScalingMode(resizedImage, palette, smoothScaling);
+}
+
+void TestCaImage::setFrameUpdatesAnimatedImage_data()
+{
+    QTest::addColumn<bool>("smoothScaling");
+    QTest::newRow("nearest") << false;
+    QTest::newRow("smooth") << true;
+}
+
+void TestCaImage::setFrameUpdatesAnimatedImage()
+{
+    QFETCH(bool, smoothScaling);
+    const QString fileName = QFINDTESTDATA("../../caQtDM_Tests/pacman-eating.gif");
+    QVERIFY2(!fileName.isEmpty(), "pacman-eating.gif fixture not found");
+
+    caImage image;
+    image.setSmoothScaling(smoothScaling);
+    image.resize(70, 70);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+    QVERIFY(image.getFrameCount() > 1);
+
+    image.setFrame(0);
+    QCoreApplication::processEvents();
+    const QImage firstFrame = renderedImage(image);
+    QCOMPARE(image.getFrame(), 0);
+    QCOMPARE(firstFrame.size(), image.contentsRect().size());
+
+    image.resize(83, 71);
+    QCoreApplication::processEvents();
+    const QImage resizedFirstFrame = renderedImage(image);
+    QCOMPARE(resizedFirstFrame.size(), image.contentsRect().size());
+
+    image.setFrame(1);
+    QCoreApplication::processEvents();
+    const QImage secondFrame = renderedImage(image);
+    QCOMPARE(image.getFrame(), 1);
+    QCOMPARE(image.getSmoothScaling(), smoothScaling);
+    QCOMPARE(secondFrame.size(), image.contentsRect().size());
+    QVERIFY(resizedFirstFrame != secondFrame);
+}
+
+void TestCaImage::invalidStateRestoresCurrentFrame_data()
+{
+    QTest::addColumn<bool>("smoothScaling");
+    QTest::newRow("nearest") << false;
+    QTest::newRow("smooth") << true;
+}
+
+void TestCaImage::invalidStateRestoresCurrentFrame()
+{
+    QFETCH(bool, smoothScaling);
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QSet<QRgb> palette;
+    const QString fileName = createScalingFixture(directory, palette);
+    QVERIFY(!fileName.isEmpty());
+
+    caImage image;
+    image.setSmoothScaling(smoothScaling);
+    image.resize(7, 5);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+
+    QLabel *label = image.findChild<QLabel *>();
+    QVERIFY(label != Q_NULLPTR);
+    const QImage rendered = renderedImage(image);
+    verifyScalingMode(rendered, palette, smoothScaling);
+    QVERIFY(!labelPixmap(label).isNull());
+
+    image.setInvalid(Qt::magenta);
+    QCoreApplication::processEvents();
+    QVERIFY(labelPixmap(label).isNull());
+
+    image.setValid();
+    QCoreApplication::processEvents();
+    QCOMPARE(image.getSmoothScaling(), smoothScaling);
+    QCOMPARE(renderedImage(image), rendered);
+}
+
+void TestCaImage::tiltAngleRerendersCurrentFrame()
 {
     QTemporaryDir directory;
     QVERIFY(directory.isValid());
@@ -133,35 +293,20 @@ void TestCaImage::resizeKeepsNearestNeighborRendering()
     image.show();
     image.setFileName(fileName, false);
     QCoreApplication::processEvents();
+    const QImage unrotated = renderedImage(image);
 
-    image.resize(13, 11);
+    image.setAngle(90);
     QCoreApplication::processEvents();
-    const QImage resizedImage = renderedImage(image);
-    QCOMPARE(resizedImage.size(), image.contentsRect().size());
-    QVERIFY(!image.getSmoothScaling());
-    QVERIFY(usesOnlyPalette(resizedImage, palette));
-}
+    const QImage rotated = renderedImage(image);
+    QCOMPARE(image.getAngle(), 90);
+    QVERIFY(hasVisiblePixels(rotated));
+    QVERIFY(rotated != unrotated);
 
-void TestCaImage::setFrameUpdatesAnimatedImage()
-{
-    const QString fileName = QFINDTESTDATA("../../caQtDM_Tests/pacman-eating.gif");
-    QVERIFY2(!fileName.isEmpty(), "pacman-eating.gif fixture not found");
-
-    caImage image;
-    image.resize(70, 70);
-    image.show();
-    image.setFileName(fileName, false);
+    image.setSmoothScaling(true);
     QCoreApplication::processEvents();
-    QVERIFY(image.getFrameCount() > 1);
-
-    image.setFrame(0);
-    QCoreApplication::processEvents();
-    const QImage firstFrame = renderedImage(image);
-    QCOMPARE(image.getFrame(), 0);
-
-    image.setFrame(1);
-    QCoreApplication::processEvents();
-    const QImage secondFrame = renderedImage(image);
-    QCOMPARE(image.getFrame(), 1);
-    QVERIFY(firstFrame != secondFrame);
+    const QImage smoothRotated = renderedImage(image);
+    QCOMPARE(image.getAngle(), 90);
+    QVERIFY(image.getSmoothScaling());
+    QVERIFY(hasVisiblePixels(smoothRotated));
+    QVERIFY(smoothRotated != rotated);
 }

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.cpp
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.cpp
@@ -1,0 +1,167 @@
+/*
+ *  This file is part of the caQtDM Framework, developed at the Paul Scherrer Institut,
+ *  Villigen, Switzerland
+ *
+ *  The caQtDM Framework is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The caQtDM Framework is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the caQtDM Framework.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2010 - 2026
+ *
+ *  Author:
+ *    Julian Houba
+ *  Contact details:
+ *    julian.houba@psi.ch
+ */
+
+#include "tst_caimage.h"
+
+#include <caimage.h>
+
+#include <QImage>
+#include <QLabel>
+#include <QMetaProperty>
+#include <QSet>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <cstring>
+
+namespace {
+
+QString createScalingFixture(QTemporaryDir &directory, QSet<QRgb> &palette)
+{
+    QImage image(2, 2, QImage::Format_ARGB32);
+    image.setPixel(0, 0, qRgba(255, 0, 0, 255));
+    image.setPixel(1, 0, qRgba(0, 255, 0, 255));
+    image.setPixel(0, 1, qRgba(0, 0, 255, 255));
+    image.setPixel(1, 1, qRgba(255, 255, 255, 255));
+
+    for(int y = 0; y < image.height(); ++y) {
+        for(int x = 0; x < image.width(); ++x) {
+            palette.insert(image.pixel(x, y));
+        }
+    }
+
+    const QString fileName = directory.filePath("scaling.png");
+    if(!image.save(fileName)) return QString();
+    return fileName;
+}
+
+bool usesOnlyPalette(const QImage &image, const QSet<QRgb> &palette)
+{
+    for(int y = 0; y < image.height(); ++y) {
+        for(int x = 0; x < image.width(); ++x) {
+            if(!palette.contains(image.pixel(x, y))) return false;
+        }
+    }
+    return true;
+}
+
+bool containsInterpolatedPixel(const QImage &image, const QSet<QRgb> &palette)
+{
+    for(int y = 0; y < image.height(); ++y) {
+        for(int x = 0; x < image.width(); ++x) {
+            if(!palette.contains(image.pixel(x, y))) return true;
+        }
+    }
+    return false;
+}
+
+QImage renderedImage(caImage &image)
+{
+    QLabel *label = image.findChild<QLabel *>();
+    if(label == Q_NULLPTR) return QImage();
+    return label->grab().toImage().convertToFormat(QImage::Format_ARGB32);
+}
+
+}
+
+void TestCaImage::smoothScalingPropertyAndPixels()
+{
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QSet<QRgb> palette;
+    const QString fileName = createScalingFixture(directory, palette);
+    QVERIFY(!fileName.isEmpty());
+
+    caImage image;
+    const int propertyIndex = image.metaObject()->indexOfProperty("smoothScaling");
+    QVERIFY(propertyIndex >= 0);
+    const QMetaProperty property = image.metaObject()->property(propertyIndex);
+    QVERIFY(property.isWritable());
+    QCOMPARE(std::strcmp(property.typeName(), "bool"), 0);
+    QVERIFY(!image.getSmoothScaling());
+
+    image.resize(7, 5);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+
+    QLabel *label = image.findChild<QLabel *>();
+    QVERIFY(label != Q_NULLPTR);
+    QCOMPARE(label->size(), image.contentsRect().size());
+    const QImage nearestImage = renderedImage(image);
+    QCOMPARE(nearestImage.size(), image.contentsRect().size());
+    QVERIFY(usesOnlyPalette(nearestImage, palette));
+
+    image.setSmoothScaling(true);
+    QCoreApplication::processEvents();
+    const QImage smoothImage = renderedImage(image);
+    QVERIFY(containsInterpolatedPixel(smoothImage, palette));
+}
+
+void TestCaImage::resizeKeepsNearestNeighborRendering()
+{
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QSet<QRgb> palette;
+    const QString fileName = createScalingFixture(directory, palette);
+    QVERIFY(!fileName.isEmpty());
+
+    caImage image;
+    image.resize(7, 5);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+
+    image.resize(13, 11);
+    QCoreApplication::processEvents();
+    const QImage resizedImage = renderedImage(image);
+    QCOMPARE(resizedImage.size(), image.contentsRect().size());
+    QVERIFY(!image.getSmoothScaling());
+    QVERIFY(usesOnlyPalette(resizedImage, palette));
+}
+
+void TestCaImage::setFrameUpdatesAnimatedImage()
+{
+    const QString fileName = QFINDTESTDATA("../../caQtDM_Tests/pacman-eating.gif");
+    QVERIFY2(!fileName.isEmpty(), "pacman-eating.gif fixture not found");
+
+    caImage image;
+    image.resize(70, 70);
+    image.show();
+    image.setFileName(fileName, false);
+    QCoreApplication::processEvents();
+    QVERIFY(image.getFrameCount() > 1);
+
+    image.setFrame(0);
+    QCoreApplication::processEvents();
+    const QImage firstFrame = renderedImage(image);
+    QCOMPARE(image.getFrame(), 0);
+
+    image.setFrame(1);
+    QCoreApplication::processEvents();
+    const QImage secondFrame = renderedImage(image);
+    QCOMPARE(image.getFrame(), 1);
+    QVERIFY(firstFrame != secondFrame);
+}

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.h
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.h
@@ -1,0 +1,42 @@
+/*
+ *  This file is part of the caQtDM Framework, developed at the Paul Scherrer Institut,
+ *  Villigen, Switzerland
+ *
+ *  The caQtDM Framework is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The caQtDM Framework is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the caQtDM Framework.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2010 - 2026
+ *
+ *  Author:
+ *    Julian Houba
+ *  Contact details:
+ *    julian.houba@psi.ch
+ */
+
+
+#ifndef TST_CAIMAGE_H
+#define TST_CAIMAGE_H
+
+#include <QObject>
+
+class TestCaImage : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void smoothScalingPropertyAndPixels();
+    void resizeKeepsNearestNeighborRendering();
+    void setFrameUpdatesAnimatedImage();
+};
+
+#endif // TST_CAIMAGE_H

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.h
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_caimage.h
@@ -35,8 +35,14 @@ class TestCaImage : public QObject
 
 private slots:
     void smoothScalingPropertyAndPixels();
-    void resizeKeepsNearestNeighborRendering();
+    void smoothScalingBeforeLoad();
+    void resizeKeepsSelectedRendering_data();
+    void resizeKeepsSelectedRendering();
+    void setFrameUpdatesAnimatedImage_data();
     void setFrameUpdatesAnimatedImage();
+    void invalidStateRestoresCurrentFrame_data();
+    void invalidStateRestoresCurrentFrame();
+    void tiltAngleRerendersCurrentFrame();
 };
 
 #endif // TST_CAIMAGE_H

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.cpp
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.cpp
@@ -31,6 +31,7 @@
 #include "tst_canumeric.h"
 #include "tst_caspinbox.h"
 #include "tst_caapplynumeric.h"
+#include "tst_caimage.h"
 #include "tst_pvdialog.h"
 
 int main(int argc, char **argv)
@@ -67,6 +68,11 @@ int main(int argc, char **argv)
 
     {
         TestCaApplyNumeric tc;
+        status |= QTest::qExec(&tc, argc, argv);
+    }
+
+    {
+        TestCaImage tc;
         status |= QTest::qExec(&tc, argc, argv);
     }
 

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.pro
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.pro
@@ -8,19 +8,22 @@ SOURCES += tst_qtcontrols.cpp \
     tst_gensoftpv.cpp \
     tst_canumeric.cpp \
     tst_caspinbox.cpp \
-    tst_caapplynumeric.cpp
+    tst_caapplynumeric.cpp \
+    tst_caimage.cpp
 
 HEADERS += tst_pvdialog.h \
     tst_gensoftpv.h \
     tst_canumeric.h \
     tst_caspinbox.h \
     tst_caapplynumeric.h \
+    tst_caimage.h \
     tst_numeric_suite.h \
     fakeformwindow.h
 
 # --- Tested classes below ---
 
-HEADERS += ../../caQtDM_QtControls/src/pvdialog.h
+HEADERS += ../../caQtDM_QtControls/src/pvdialog.h \
+    ../../caQtDM_QtControls/src/caimage.h
 
 SOURCES += ../../caQtDM_QtControls/src/pvdialog.cpp
 

--- a/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.pro
+++ b/caQtDM_UnitTests/tst_qtcontrols/tst_qtcontrols.pro
@@ -22,8 +22,7 @@ HEADERS += tst_pvdialog.h \
 
 # --- Tested classes below ---
 
-HEADERS += ../../caQtDM_QtControls/src/pvdialog.h \
-    ../../caQtDM_QtControls/src/caimage.h
+HEADERS += ../../caQtDM_QtControls/src/pvdialog.h
 
 SOURCES += ../../caQtDM_QtControls/src/pvdialog.cpp
 

--- a/caQtDM_docs/source/caQtDM_Manual.rst
+++ b/caQtDM_docs/source/caQtDM_Manual.rst
@@ -2241,7 +2241,10 @@ is the equivalent of image in MEDM.
    channel specified. A multiple-frame Image updates with some
    speed even with no process variables specified for the Dynamic Attribute.
    Use the Image Calc expression and the process variables in the
-   Dynamic Attribute to specify when to display each color. 
+   Dynamic Attribute to specify when to display each color. Images are scaled
+   with nearest-neighbor sampling by default, which keeps low-resolution
+   graphics sharp. Enable the ``smoothScaling`` property in Designer for
+   filtered scaling of photographic or high-resolution images.
    
    .. caution: SGA is 20 years old and may be archaic.  ImageMagick?
 
@@ -4381,4 +4384,3 @@ When running caQtDM Web in a Docker container, you can use the following additio
 
    "``ENTRY_PANEL``", "Path to the main caQtDM UI file that should be served by default", "Required, default is the test panel if not specified"
    "``EXTRA_ARGS``", "Additional command line arguments to pass to caQtDM, as docker would not allow passing them directly", "Optional, default is empty"
-


### PR DESCRIPTION
caImage now uses nearest-neighbor scaling by default, preserving sharp scaled low-resolution graphics. A new smoothScaling Designer property enables filtered scaling for photos and high-resolution images.

examples:
smooth scaling disabled (default):

<img width="88" height="66" alt="Bildschirmfoto_20260907_120447" src="https://github.com/user-attachments/assets/d276ab95-7bce-453d-88e9-c854d972a835" />
<img width="1402" height="1086" alt="Bildschirmfoto_20260907_120721" src="https://github.com/user-attachments/assets/309fdf8f-a4db-454b-a8d3-092925aaccfb" />


smooth scaling enabled:
<img width="88" height="66" alt="Bildschirmfoto_20260907_120510" src="https://github.com/user-attachments/assets/504749ca-a8e5-4e38-86e0-4d9516641301" />
<img width="1402" height="1086" alt="Bildschirmfoto_20260907_120744" src="https://github.com/user-attachments/assets/58350bf0-2842-4ec9-ab40-bbd790492489" />
